### PR TITLE
Inline git metadata into Jekyll build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy static site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,63 +1,8 @@
-# dependencies
-/node_modules
-
-# testing
-/coverage
-
-# production
-/dist
-/tmp
-
-# misc
-.DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*.DS_Store
-.AppleDouble
-.LSOverride
-*.swp
-*.swo
-public/fonts
-
-# Node
-node_modules
-
-# Icon must end with two \r
-Icon
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
-
-Thumbs.db
-db.json
-*.log
-public/
-.deploy*/
-.idea/
-*.log
-*.iml
-.tern-port
-yarn.lock
-package-lock.json
+_site/
+.jekyll-cache/
+.sass-cache/
+.bundle/
+vendor/
+Gemfile.lock
 node_modules/
+.DS_Store

--- a/DIGEST.md
+++ b/DIGEST.md
@@ -1,0 +1,21 @@
+## 🔢
+### 12
+Years in tech
+
+### >136
+Web3 Vulnerabilities assessed
+
+### 21/46
+Programming Competitions Won/Attended
+
+### ~900
+Workshop Attendees
+
+### ~700
+Consistent readers on [dev.to](https://dev.to/meeshbhoombah)
+
+### > 3,098
+Hours dedicated to diversifying tech through education
+
+### ~100
+Projects Built

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins

--- a/HERO.md
+++ b/HERO.md
@@ -1,0 +1,5 @@
+# Meeshbhoombah
+
+**Governance focused decentralized systems engineering.**
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eleifend, tortor et congue congue, tellus eros commodo est, vitae euismod elit purus at tortor. Suspendisse placerat ex non massa auctor, ut iaculis urna interdum.

--- a/README.md
+++ b/README.md
@@ -1,93 +1,29 @@
-Meeshbhoombah 𝐱 WWW
+# meeshbhoombah.github.io
 
-## 🔢
-### 12
-Years in tech
+Static site for [meeshbhoombah.github.io](https://meeshbhoombah.github.io) built with [Jekyll](https://jekyllrb.com/) and published via GitHub Pages.
 
-### >136
-Web3 Vulnerabilities assessed
+## Structure
 
-### 21/46
-Programming Competitions Won/Attended
+- `index.md` composes the homepage by stitching together `HERO.md`, `WORK.md`, `DIGEST.md`, and the live writing feed grouped by category.
+- `_writing/` contains Markdown sources for long-form posts. Files marked `status: live` are published to `/writing/...` and surface automatically on the homepage.
+- `_layouts/` defines the base, writing entry, and writing index layouts. Titles fall back to the first Markdown heading, so posts do not need explicit `title` front matter.
+- `_plugins/writing_metadata.rb` reads git history at build time to capture first-live dates and heading-derived titles for published articles.
 
-### ~900
-Workshop Attendees
+## Local development
 
-### ~700
-Consistent readers on [dev.to](https://dev.to/meeshbhoombah)
+1. Install Ruby (>= 3.0) and Bundler.
+2. Install dependencies:
+   ```bash
+   bundle install --path vendor/bundle
+   ```
+3. Serve the site locally:
+   ```bash
+   bundle exec jekyll serve
+   ```
+   The site will be available at `http://localhost:4000`.
 
-### > 3,098 
-Hours dedicated to diversifying tech through education
+Ensure your clone has full git history so first-live dates can be discovered while the site builds.
 
-### ~100
-Projects Built
+## Deployment
 
-## 🔁
-### Follow Me
-- [Twitter](https://twitter.com/meeshbhoombah)
-- [Medium](https://meeshbhoombah.medium.com/)
-- [dev.to](https://dev.to/meeshbhoombah)
-- [GitHub](https://github.com/meeshbhoombah/)
-- [LinkedIn](https://www.linkedin.com/in/meeshbhoombah/)
-
-## 🤔
-### Now
-- [Architect](https://twitter.com/_thearchproj_)
-
-### Previously
-- [Sigma Prime](https://sigmaprime.io/)
-    + Worked on:
-        * An off-chain rollup system securing $330,000,000
-        * A Bitcoin L2 based on [reth v1.5.0](https://github.com/paradigmxyz/reth/releases/tag/v1.0.5) 
-          with 10,000,000+ tx & 150,000+ unique addresses
-        * An internal log auditing system for a company worth $2,000,000,000
-- [JusticeText](https://justicetext.com/)
-    + Worked on:
-        * Core product, leading to $25,000 MRR a $2,000,000 raise
-- [Commonwealth](https://commonwealth.im/)
-    + Worked on:
-        * Core product, scaling DAU by 33%
-- [Tru-Breed](https://www.tru-breed.com/)
-    + Worked on:
-        * A private, pipelined, optimized fork of [ipyrad](https://github.com/dereneaton/ipyrad)
-- [Make School](https://makeschool.org/)
-    + Worked on:
-        * Teaching ~200 students cryptocurrency concepts (economics, computer science, game theory, NFTs, DAOs)
-        * Delivering three products quarterly, of note:
-            - A markov-chain based Eminem lyric generator
-            - An ecommerce system for cannabis dispenaries
-            - A StackOverflow-esque system for Slack
-        * Building community
-- [CodeDay](https://www.codeday.org/)
-- [BlockchainEDU](https://www.blockchainedu.org/)
-
-## 🖋
-### Cryptocurrencies
-- Decentralized Autonomous Organizations
-    + [What Went DAOn](https://meeshbhoombah.medium.com/what-went-daon-e11ba29a5931)
-- Memecoins
-    + [Memecoins are Misunderstood](https://meeshbhoombah.medium.com/memecoins-are-misunderstood-a7485486e4b7)
-
-### Social Science
-Coming Soon
-
-### Startups
-- [Getting Started](/writing/startups/getting-started.md)
-
-### Computing
-- Formal Verification
-    1. [The Foundation of Ethereum Smart Contracts](https://dev.to/meeshbhoombah/formal-verification-of-ethereum-smart-contracts-4mb4)
-    2. [Bridging Theory and Practice](https://dev.to/meeshbhoombah/formal-verification-bridging-theory-and-practice-2931`)
-    3. [An Example](https://dev.to/meeshbhoombah/formal-verification-an-example-33c)
-- Functional Programming
-    + [A Misfit for Backend Engineering](https://dev.to/meeshbhoombah/functional-programming-a-misfit-for-backend-engineering-2aak)
-- Invariance
-    + [Be Invariant](https://dev.to/meeshbhoombah/be-invariant-4hn2)
-
-### Food
-- [Recommendations](/writing/food/recommendations.md)
-
-## ♾
-[Outputs](https://meeshbhoombah2020.notion.site/Outputs-25bce498609c4d089bc670ec3dfce8ad)
-
-
+GitHub Actions builds and deploys the static site on every push to `main` using the checked-in workflow.

--- a/WORK.md
+++ b/WORK.md
@@ -1,0 +1,30 @@
+## 🤔
+### Now
+- [Architect](https://twitter.com/_thearchproj_)
+
+### Previously
+- [Sigma Prime](https://sigmaprime.io/)
+    + Worked on:
+        * An off-chain rollup system securing $330,000,000
+        * A Bitcoin L2 based on [reth v1.5.0](https://github.com/paradigmxyz/reth/releases/tag/v1.0.5)
+          with 10,000,000+ tx & 150,000+ unique addresses
+        * An internal log auditing system for a company worth $2,000,000,000
+- [JusticeText](https://justicetext.com/)
+    + Worked on:
+        * Core product, leading to $25,000 MRR a $2,000,000 raise
+- [Commonwealth](https://commonwealth.im/)
+    + Worked on:
+        * Core product, scaling DAU by 33%
+- [Tru-Breed](https://www.tru-breed.com/)
+    + Worked on:
+        * A private, pipelined, optimized fork of [ipyrad](https://github.com/dereneaton/ipyrad)
+- [Make School](https://makeschool.org/)
+    + Worked on:
+        * Teaching ~200 students cryptocurrency concepts (economics, computer science, game theory, NFTs, DAOs)
+        * Delivering three products quarterly, of note:
+            - A markov-chain based Eminem lyric generator
+            - An ecommerce system for cannabis dispenaries
+            - A StackOverflow-esque system for Slack
+        * Building community
+- [CodeDay](https://www.codeday.org/)
+- [BlockchainEDU](https://www.blockchainedu.org/)

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,25 @@
+title: Meeshbhoombah
+url: https://meeshbhoombah.github.io
+baseurl: ""
+description: Governance focused decentralized systems engineering.
+markdown: kramdown
+collections:
+  writing:
+    output: true
+    permalink: /writing/:path/
+defaults:
+  - scope:
+      path: ""
+      type: writing
+    values:
+      layout: writing
+      status: draft
+exclude:
+  - node_modules
+  - vendor
+  - Gemfile.lock
+  - package-lock.json
+  - HERO.md
+  - WORK.md
+  - DIGEST.md
+plugins: []

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% assign page_title = page.title %}
+    {% if page_title == nil or page_title == '' %}
+      {% assign raw_lines = page.content | split: '\n' %}
+      {% for line in raw_lines %}
+        {% assign trimmed = line | strip %}
+        {% if trimmed != '' and trimmed | slice: 0, 2 == '# ' %}
+          {% assign page_title = trimmed | remove_first: '# ' | strip %}
+          {% break %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+    <title>{% if page_title %}{{ page_title }} · {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{{ page.description | default: site.description }}">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="wrap">
+        <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+        <nav class="site-nav">
+          <a href="{{ '/' | relative_url }}">Home</a>
+          <a href="{{ '/writing/' | relative_url }}">Writing</a>
+        </nav>
+      </div>
+    </header>
+    <main class="site-main wrap">
+      {{ content }}
+    </main>
+    <footer class="site-footer">
+      <div class="wrap">
+        <p>&copy; {{ site.time | date: '%Y' }} {{ site.title }}</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/_layouts/writing.html
+++ b/_layouts/writing.html
@@ -1,0 +1,37 @@
+---
+layout: default
+---
+{% assign derived_title = page.title %}
+{% assign raw_lines = page.content | split: '\n' %}
+{% assign found_heading = false %}
+{% capture body_markdown %}
+{% for line in raw_lines %}
+  {% assign trimmed = line | strip %}
+  {% if found_heading == false and trimmed != '' and trimmed | slice: 0, 2 == '# ' %}
+    {% if derived_title == nil or derived_title == '' %}
+      {% assign derived_title = trimmed | remove_first: '# ' | strip %}
+    {% endif %}
+    {% assign found_heading = true %}
+  {% else %}
+{{ line }}{% unless forloop.last %}
+{% endunless %}
+  {% endif %}
+{% endfor %}
+{% endcapture %}
+<article class="writing-entry">
+  <header>
+    {% if derived_title %}
+    <h1>{{ derived_title }}</h1>
+    {% endif %}
+    {% if page.description %}
+    <p class="lede">{{ page.description }}</p>
+    {% endif %}
+    {% assign first_live = page.first_live_at %}
+    {% if first_live %}
+    <p class="meta">First published {{ first_live | date: '%B %-d, %Y' }}</p>
+    {% endif %}
+  </header>
+  <div class="content">
+    {{ body_markdown | markdownify }}
+  </div>
+</article>

--- a/_layouts/writing_index.html
+++ b/_layouts/writing_index.html
@@ -1,0 +1,55 @@
+---
+layout: default
+---
+<section class="writing-index">
+  <header>
+    {% assign derived_title = page.title %}
+    {% if derived_title == nil or derived_title == '' %}
+      {% assign lines = page.content | split: '\n' %}
+      {% for line in lines %}
+        {% assign trimmed = line | strip %}
+        {% if trimmed != '' and trimmed | slice: 0, 2 == '# ' %}
+          {% assign derived_title = trimmed | remove_first: '# ' | strip %}
+          {% break %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+    {% if derived_title %}<h1>{{ derived_title }}</h1>{% endif %}
+    {% if page.description %}
+    <p class="lede">{{ page.description }}</p>
+    {% endif %}
+  </header>
+  <div class="intro">
+    {{ content | markdownify }}
+  </div>
+  {% assign categories = 'Cryptocurrencies|Social Sciences|Computing|Startups|Food' | split: '|' %}
+  {% assign live_posts = site.writing | where: 'status', 'live' %}
+  {% for category in categories %}
+    {% assign categorized = live_posts | where: 'category', category | sort: 'relative_path' %}
+    {% if categorized != empty %}
+    <section class="category">
+      <h2>{{ category }}</h2>
+      <ul>
+      {% for post in categorized %}
+        {% assign post_title = post.title | default: post.data.title %}
+        {% if post_title == nil or post_title == '' %}
+          {% assign post_lines = post.content | split: '\n' %}
+          {% for line in post_lines %}
+            {% assign trimmed = line | strip %}
+            {% if trimmed != '' and trimmed | slice: 0, 2 == '# ' %}
+              {% assign post_title = trimmed | remove_first: '# ' | strip %}
+              {% break %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% assign first_live = post.first_live_at %}
+        <li>
+          <a href="{{ post.url | relative_url }}">{{ post_title }}</a>
+          {% if first_live %}<span class="meta">{{ first_live | date: '%b %-d, %Y' }}</span>{% endif %}
+        </li>
+      {% endfor %}
+      </ul>
+    </section>
+    {% endif %}
+  {% endfor %}
+</section>

--- a/_plugins/writing_metadata.rb
+++ b/_plugins/writing_metadata.rb
@@ -1,0 +1,65 @@
+require 'open3'
+require 'time'
+
+module Jekyll
+  class WritingMetadataGenerator < Generator
+    safe true
+    priority :low
+
+    def generate(site)
+      writing = site.collections['writing']
+      return unless writing
+
+      writing.docs.each do |doc|
+        next unless live_post?(doc)
+
+        doc.data['first_live_at'] ||= discover_first_live(site, doc)
+        doc.data['title'] = derive_title(doc) if missing?(doc.data['title'])
+      end
+    end
+
+    private
+
+    def live_post?(doc)
+      status = doc.data['status']
+      status = status.downcase if status.respond_to?(:downcase)
+      status == 'live'
+    end
+
+    def missing?(value)
+      value.nil? || (value.respond_to?(:empty?) && value.empty?)
+    end
+
+    def derive_title(doc)
+      doc.content.to_s.each_line do |line|
+        stripped = line.strip
+        next unless stripped.start_with?('# ')
+
+        return stripped.sub(/^#\s+/, '').strip
+      end
+      nil
+    end
+
+    def discover_first_live(site, doc)
+      return unless git_available?
+
+      path = File.expand_path(doc.path, site.source)
+      command = ['git', 'log', '--diff-filter=A', '--follow', '--format=%aI', '-1', '--', path]
+      stdout, status = Open3.capture2(*command)
+      return unless status.success?
+
+      stamp = stdout.strip
+      stamp.empty? ? nil : Time.parse(stamp)
+    rescue StandardError => e
+      Jekyll.logger.warn('writing_metadata', "Unable to read first-live date for #{doc.relative_path}: #{e.message}")
+      nil
+    end
+
+    def git_available?
+      return @git_available unless @git_available.nil?
+
+      _, status = Open3.capture2('git', 'rev-parse', '--is-inside-work-tree')
+      @git_available = status.success?
+    end
+  end
+end

--- a/_writing/cryptocurrencies/EVM.md
+++ b/_writing/cryptocurrencies/EVM.md
@@ -1,4 +1,13 @@
-# The EVM
+---
+layout: writing
+status: draft
+description: Technical notes on the Ethereum Virtual Machine.
+category: Cryptocurrencies
+tags: [writing, cryptocurrencies]
+---
+
+# EVM
+
 Synthesized learnings from various sources and explorations. Primarily:
 - The Ethereum Yellowpaper
 - My own Copywork of OpenZepplin's Smart Contract Suite (v0.8.0)

--- a/_writing/food/recommendations.md
+++ b/_writing/food/recommendations.md
@@ -1,4 +1,12 @@
-Recommendations
+---
+layout: writing
+status: live
+description: A running list of noteworthy bites and sips.
+category: Food
+tags: [writing, food]
+---
+
+# Food Recommendations
 
 ## Bay Area
 - Quickly's
@@ -33,5 +41,3 @@ Recommendations
 - Lola
 - Al Abasha
 - Dick's
-
-

--- a/_writing/startups/getting-started.md
+++ b/_writing/startups/getting-started.md
@@ -1,4 +1,12 @@
-Getting Started
+---
+layout: writing
+status: live
+description: Steps to reach product-market fit with lean experimentation.
+category: Startups
+tags: [writing, startups]
+---
+
+# Getting Started
 
 **Your Objective:** Product-Market Fit
 
@@ -54,4 +62,3 @@ Synthesize all your research into a document depicting the future
 ### Where to Go From Here
 - Fundraising
 - Finances
-

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,100 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--bg, #fff);
+  color: var(--fg, #111);
+  line-height: 1.6;
+}
+
+.wrap {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header,
+.site-footer {
+  background: rgba(0, 0, 0, 0.04);
+  padding: 1.5rem 0;
+}
+
+.site-title {
+  font-weight: 700;
+  text-decoration: none;
+  color: inherit;
+  font-size: 1.1rem;
+}
+
+.site-nav a {
+  margin-left: 1rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.site-main {
+  padding: 2.5rem 0 4rem;
+}
+
+h1, h2, h3 {
+  line-height: 1.2;
+}
+
+.lede {
+  font-size: 1.1rem;
+  max-width: 60ch;
+}
+
+.writing-entry header {
+  margin-bottom: 2rem;
+}
+
+.writing-entry .meta,
+.writing-index .meta {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.9rem;
+  margin-left: 0.5rem;
+}
+
+.writing-index ul,
+.home-writing ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.writing-index li,
+.home-writing li {
+  margin-bottom: 0.5rem;
+}
+
+.home-writing section {
+  margin-bottom: 2rem;
+}
+
+.home-writing h2 {
+  margin-top: 0;
+}
+
+.home-writing h3 {
+  margin-bottom: 0.75rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #050505;
+    --fg: #f5f5f5;
+  }
+
+  .site-header,
+  .site-footer {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .writing-entry .meta,
+  .writing-index .meta,
+  .home-writing .meta {
+    color: rgba(255, 255, 255, 0.7);
+  }
+}

--- a/index.md
+++ b/index.md
@@ -1,0 +1,54 @@
+---
+layout: default
+permalink: /
+title: Meeshbhoombah
+description: Governance focused decentralized systems engineering.
+---
+{% capture hero_markdown %}
+{% include_relative HERO.md %}
+{% endcapture %}
+{{ hero_markdown | markdownify }}
+
+{% capture work_markdown %}
+{% include_relative WORK.md %}
+{% endcapture %}
+{{ work_markdown | markdownify }}
+
+{% capture digest_markdown %}
+{% include_relative DIGEST.md %}
+{% endcapture %}
+{{ digest_markdown | markdownify }}
+
+<section class="home-writing">
+  <h2>🖋️ Writing</h2>
+  {% assign categories = 'Cryptocurrencies|Social Sciences|Computing|Startups|Food' | split: '|' %}
+  {% assign live_posts = site.writing | where: 'status', 'live' %}
+  {% for category in categories %}
+    {% assign categorized = live_posts | where: 'category', category | sort: 'relative_path' %}
+    {% if categorized != empty %}
+    <section class="category">
+      <h3>{{ category }}</h3>
+      <ul>
+        {% for post in categorized %}
+          {% assign post_title = post.title | default: post.data.title %}
+          {% if post_title == nil or post_title == '' %}
+            {% assign post_lines = post.content | split: '\n' %}
+            {% for line in post_lines %}
+              {% assign trimmed = line | strip %}
+              {% if trimmed != '' and trimmed | slice: 0, 2 == '# ' %}
+                {% assign post_title = trimmed | remove_first: '# ' | strip %}
+                {% break %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+          {% assign first_live = post.first_live_at %}
+          <li>
+            <a href="{{ post.url | relative_url }}">{{ post_title }}</a>
+            {% if first_live %}<span class="meta">{{ first_live | date: '%b %-d, %Y' }}</span>{% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+    {% endif %}
+  {% endfor %}
+</section>

--- a/writing/README.md
+++ b/writing/README.md
@@ -1,6 +1,0 @@
-# Writing
-Collected works...
-- Research
-- Articles
-- Notes
-

--- a/writing/index.md
+++ b/writing/index.md
@@ -1,0 +1,7 @@
+---
+layout: writing_index
+title: Writing
+permalink: /writing/
+description: Essays, notes, and research from across the network state.
+---
+Browse the full catalog of live writing below. Entries update automatically as front matter changes.


### PR DESCRIPTION
## Summary
- compute first-live dates and derived titles during the Jekyll build with a plugin so no separate scripts are required
- update the homepage and writing layouts to read git-driven metadata directly from each document
- streamline the deployment workflow to install Ruby and run the Jekyll build before publishing to GitHub Pages

## Testing
- bundle install --path vendor/bundle *(fails: rubygems.org returns 403 Forbidden in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fc42eae9d083299bbcfb7c76cbf5d5