### PR TITLE
Add dynamic writing sections to homepage

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,6 +1,125 @@
 import fs from 'fs';
 import path from 'path';
 
+const WRITING_CATEGORY_LABELS = {
+  cryptocurrencies: 'Cryptocurrencies',
+  'social-sciences': 'Social Sciences',
+  computing: 'Computing',
+  startups: 'Startups',
+  food: 'Food',
+};
+
+function parseFrontMatter(markdown) {
+  if (!markdown.startsWith('---')) {
+    return { data: {}, content: markdown };
+  }
+
+  const closingIndex = markdown.indexOf('\n---', 3);
+  if (closingIndex === -1) {
+    return { data: {}, content: markdown };
+  }
+
+  const frontMatter = markdown.slice(3, closingIndex).trim();
+  const content = markdown.slice(closingIndex + 4);
+  const data = {};
+
+  for (const line of frontMatter.split(/\r?\n/)) {
+    const separatorIndex = line.indexOf(':');
+    if (separatorIndex === -1) continue;
+
+    const key = line.slice(0, separatorIndex).trim();
+    const rawValue = line.slice(separatorIndex + 1).trim();
+    const value = rawValue.replace(/^['"]/, '').replace(/['"]$/, '');
+    if (key) {
+      data[key] = value;
+    }
+  }
+
+  return { data, content };
+}
+
+function getFirstHeading(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  for (const line of lines) {
+    const match = line.match(/^#\s+(.*)$/);
+    if (match) {
+      return match[1].trim();
+    }
+  }
+  return '';
+}
+
+function getLiveWritingByCategory() {
+  const baseDir = path.join(process.cwd(), 'writing');
+  const sections = [];
+
+  for (const [folder, label] of Object.entries(WRITING_CATEGORY_LABELS)) {
+    const directoryPath = path.join(baseDir, folder);
+    const entries = [];
+
+    if (fs.existsSync(directoryPath)) {
+      const files = fs.readdirSync(directoryPath).filter((file) => file.endsWith('.md'));
+
+      for (const file of files) {
+        const filePath = path.join(directoryPath, file);
+        const slug = file.replace(/\.md$/, '');
+        const markdown = fs.readFileSync(filePath, 'utf8');
+        const { data, content } = parseFrontMatter(markdown);
+
+        if (!data || data.status !== 'live') {
+          continue;
+        }
+
+        const title = getFirstHeading(content) || slug;
+        const description = data.description ? String(data.description) : '';
+        const href = `writing/${folder}/${slug}`;
+
+        entries.push({
+          title,
+          description,
+          href,
+        });
+      }
+    }
+
+    sections.push({
+      label,
+      entries,
+    });
+  }
+
+  return sections;
+}
+
+function renderWritingSections() {
+  const sections = getLiveWritingByCategory();
+  const rendered = [];
+
+  for (const section of sections) {
+    const { label, entries } = section;
+    const heading = `<h3>${escapeHtml(label)}</h3>`;
+
+    if (!entries.length) {
+      rendered.push(`${heading}\n<p>No live writing yet.</p>`);
+      continue;
+    }
+
+    const items = entries
+      .map(({ title, description, href }) => {
+        const link = `<a href="${escapeHtml(href)}">${escapeHtml(title)}</a>`;
+        if (description) {
+          return `<li>${link}<p>${escapeHtml(description)}</p></li>`;
+        }
+        return `<li>${link}</li>`;
+      })
+      .join('\n');
+
+    rendered.push(`${heading}\n<ul>\n${items}\n</ul>`);
+  }
+
+  return rendered.join('\n');
+}
+
 function escapeHtml(value) {
   return value
     .replace(/&/g, '&amp;')
@@ -142,12 +261,16 @@ export default function HomePage() {
   const filePath = path.join(process.cwd(), 'HOME.md');
   const fileContent = fs.readFileSync(filePath, 'utf8');
   const html = markdownToHtml(fileContent);
+  const writingSectionsHtml = renderWritingSections();
+  const enhancedHtml = writingSectionsHtml
+    ? html.replace('<h2>🖋️</h2>', `<h2>🖋️</h2>\n${writingSectionsHtml}`)
+    : html;
 
   return (
     <main className="content">
       <article
         className="markdown"
-        dangerouslySetInnerHTML={{ __html: html }}
+        dangerouslySetInnerHTML={{ __html: enhancedHtml }}
       />
     </main>
   );


### PR DESCRIPTION
## Summary
- add helpers to collect live writing entries from markdown front matter
- render writing category sections beneath the pen heading on the homepage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690020d387fc832983b61c6b0eb3912d