### PR TITLE
Add theme toggle and section label refinements

### DIFF
--- a/app/components/ThemeToggle.jsx
+++ b/app/components/ThemeToggle.jsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useTheme } from '../theme-provider';
+
+export default function ThemeToggle() {
+  const { resolvedTheme, toggleTheme } = useTheme();
+  const nextMode = resolvedTheme === 'dark' ? 'Light' : 'Dark';
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={toggleTheme}
+      aria-label={`Switch to ${nextMode.toLowerCase()} mode`}
+    >
+      {nextMode} mode
+    </button>
+  );
+}

--- a/app/components/home/DigestSection.jsx
+++ b/app/components/home/DigestSection.jsx
@@ -21,12 +21,12 @@ const stats = [
 
 export default function DigestSection() {
   return (
-    <section className="home-section" aria-labelledby="home-digest-heading">
-      <h2 id="home-digest-heading">🔢</h2>
+    <section className="home-section" aria-label="Digest">
+      <p className="section-label">Digest</p>
       <div className="home-digest-grid">
         {stats.map(({ value, description }, index) => (
           <div className="home-digest-item" key={`${value}-${index}`}>
-            <h3>{value}</h3>
+            <p className="stat-value">{value}</p>
             <p>{description}</p>
           </div>
         ))}

--- a/app/components/home/FollowSection.jsx
+++ b/app/components/home/FollowSection.jsx
@@ -8,9 +8,8 @@ const links = [
 
 export default function FollowSection() {
   return (
-    <section className="home-section" aria-labelledby="home-follow-heading">
-      <h2 id="home-follow-heading">🔁</h2>
-      <h3>Follow Me</h3>
+    <section className="home-section" aria-label="Follow">
+      <p className="section-label">Follow</p>
       <ul>
         {links.map(({ label, href }) => (
           <li key={label}>

--- a/app/components/home/HeroSection.jsx
+++ b/app/components/home/HeroSection.jsx
@@ -1,6 +1,6 @@
 export default function HeroSection() {
   return (
-    <section className="home-section">
+    <section className="home-section hero-section">
       <p>
         <strong>Governance-focused decentralized systems engineering.</strong>
       </p>

--- a/app/components/home/OutputsSection.jsx
+++ b/app/components/home/OutputsSection.jsx
@@ -1,7 +1,7 @@
 export default function OutputsSection() {
   return (
-    <section className="home-section" aria-labelledby="home-outputs-heading">
-      <h2 id="home-outputs-heading">♾</h2>
+    <section className="home-section" aria-label="Outputs">
+      <p className="section-label">Outputs</p>
       <p>
         <a href="https://meeshbhoombah2020.notion.site/Outputs-25bce498609c4d089bc670ec3dfce8ad">
           Outputs

--- a/app/components/home/WorkSection.jsx
+++ b/app/components/home/WorkSection.jsx
@@ -112,10 +112,10 @@ function renderContribution(contribution, keyPrefix) {
 
 export default function WorkSection() {
   return (
-    <section className="home-section" aria-labelledby="home-work-heading">
-      <h2 id="home-work-heading">🤔</h2>
+    <section className="home-section" aria-label="Work">
+      <p className="section-label">Work</p>
       <div className="home-subsection">
-        <h3>Now</h3>
+        <p className="subsection-label">Now</p>
         <ul>
           {nowRoles.map(({ name, href }) => (
             <li key={name}>
@@ -125,7 +125,7 @@ export default function WorkSection() {
         </ul>
       </div>
       <div className="home-subsection">
-        <h3>Previously</h3>
+        <p className="subsection-label">Previously</p>
         <ul>
           {previousRoles.map(({ name, href, contributions = [] }) => (
             <li key={name}>

--- a/app/components/home/WritingSection.jsx
+++ b/app/components/home/WritingSection.jsx
@@ -4,11 +4,11 @@ export default function WritingSection({ sections }) {
   );
 
   return (
-    <section className="home-section" aria-labelledby="home-writing-heading">
-      <h2 id="home-writing-heading">🖋️</h2>
+    <section className="home-section" aria-label="Writing">
+      <p className="section-label">Writing</p>
       {writingSections.map(({ label, entries }) => (
         <div className="home-writing-category" key={label}>
-          <h3>{label}</h3>
+          <p className="subsection-label">{label}</p>
           {entries.length > 0 ? (
             <ul>
               {entries.map(({ title, description, href }) => (

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,68 +1,140 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap');
+
 :root {
   color-scheme: light dark;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #0f0f0f;
-  color: #f5f5f5;
+  --color-background: #ffffff;
+  --color-foreground: #000000;
+  --color-muted: #4b4b4b;
+  --color-muted-strong: #2e2e2e;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: #000000;
+    --color-foreground: #ffffff;
+    --color-muted: #b5b5b5;
+    --color-muted-strong: #e0e0e0;
+  }
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+  --color-background: #ffffff;
+  --color-foreground: #000000;
+  --color-muted: #4b4b4b;
+  --color-muted-strong: #2e2e2e;
+}
+
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-muted: #b5b5b5;
+  --color-muted-strong: #e0e0e0;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html {
+  font-size: 13.3333px;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: 'JetBrains Mono', monospace;
 }
 
 .page-container {
   margin: 0 auto;
   max-width: 760px;
-  padding: 3rem 1.5rem 4rem;
+  padding: 128px 1.5rem 4rem;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 64px;
 }
 
 .page-header,
 .page-footer {
   display: flex;
-  justify-content: center;
+  align-items: center;
+  justify-content: space-between;
   font-size: 0.9rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #a3a3a3;
+  color: var(--color-muted);
+}
+
+.page-footer {
+  justify-content: flex-start;
 }
 
 .site-title {
   font-weight: 600;
+  letter-spacing: 0.12em;
+  color: var(--color-foreground);
+}
+
+.theme-toggle {
+  appearance: none;
+  border: 1px solid var(--color-muted);
+  background: transparent;
+  color: inherit;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  border-color: var(--color-muted-strong);
+  outline: none;
 }
 
 .content {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 64px;
 }
 
 .home-content {
-  gap: 2rem;
+  gap: 64px;
 }
 
 .home-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 16px;
 }
 
-.home-subsection {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+.section-label {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
 }
 
+.subsection-label {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.home-subsection,
 .home-writing-category {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 12px;
 }
 
 .home-writing-category ul {
@@ -70,90 +142,85 @@ body {
 }
 
 .home-writing-category li p {
-  margin: 0.5rem 0 0.25rem;
+  margin: 0;
 }
 
 .home-digest-grid {
   display: grid;
-  gap: 1.25rem;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
 .home-digest-item {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 12px;
 }
 
-.markdown h1,
-.markdown h2,
-.markdown h3,
-.home-section h1,
-.home-section h2,
-.home-section h3 {
-  margin: 2rem 0 1rem;
+.stat-value {
+  margin: 0;
+  font-size: 1.4rem;
   font-weight: 600;
-}
-
-.markdown h1,
-.home-section h1 {
-  font-size: 2.8rem;
-}
-
-.markdown h2,
-.home-section h2 {
-  font-size: 1.8rem;
-}
-
-.markdown h3,
-.home-section h3 {
-  font-size: 1.3rem;
-  color: #cfcfcf;
+  color: var(--color-muted-strong);
 }
 
 .markdown p,
 .home-section p {
+  font-size: 1rem;
   line-height: 1.7;
-  margin: 0.75rem 0;
+  margin: 0;
 }
 
-.markdown ul,
+.hero-section p {
+  font-size: 1.2rem;
+}
+
+.home-section p + p {
+  margin-top: 8px;
+}
+
 .home-section ul {
   list-style: disc;
   padding-left: 1.4rem;
-  margin: 0.5rem 0;
+  margin: 0;
 }
 
-.markdown ul ul,
 .home-section ul ul {
   list-style: circle;
   padding-left: 1.4rem;
 }
 
-.markdown a,
-.home-section a {
-  color: #7dd3fc;
-  text-decoration: none;
+.home-section li,
+.page-footer {
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
-.markdown a:hover,
-.markdown a:focus,
-.home-section a:hover,
-.home-section a:focus {
+a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+a:hover,
+a:focus-visible {
   text-decoration: underline;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    background-color: #fafafa;
-    color: #1a1a1a;
+@media (max-width: 600px) {
+  .page-container {
+    padding: 96px 1.2rem 3rem;
   }
 
   .page-header,
   .page-footer {
-    color: #6b7280;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
   }
 
-  .markdown a {
-    color: #0369a1;
+  .theme-toggle {
+    align-self: flex-end;
   }
 }

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,24 +1,29 @@
 import './globals.css';
+import ThemeToggle from './components/ThemeToggle';
+import { ThemeProvider } from './theme-provider';
 
 export const metadata = {
-  title: 'Meesh Bhoombah',
+  title: 'Meeshbhoombah.',
   description:
     'Governance-focused decentralized systems engineering and resilient coordination mechanisms.',
 };
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body>
-        <div className="page-container">
-          <header className="page-header">
-            <span className="site-title">Meesh Bhoombah</span>
-          </header>
-          {children}
-          <footer className="page-footer">
-            <span>© {new Date().getFullYear()} Meesh Bhoombah</span>
-          </footer>
-        </div>
+        <ThemeProvider>
+          <div className="page-container">
+            <header className="page-header">
+              <span className="site-title">Meeshbhoombah.</span>
+              <ThemeToggle />
+            </header>
+            {children}
+            <footer className="page-footer">
+              <span>© {new Date().getFullYear()} Meesh Bhoombah</span>
+            </footer>
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -14,11 +14,11 @@ export default function HomePage() {
   return (
     <main className="content home-content">
       <HeroSection />
-      <WorkSection />
+      <FollowSection />
       <WritingSection sections={writingSections} />
       <OutputsSection />
       <DigestSection />
-      <FollowSection />
+      <WorkSection />
     </main>
   );
 }

--- a/app/theme-provider.jsx
+++ b/app/theme-provider.jsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const STORAGE_KEY = 'meesh-theme-preference';
+
+const ThemeContext = createContext(null);
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('system');
+  const [systemTheme, setSystemTheme] = useState('dark');
+
+  useEffect(() => {
+    const storedPreference = window.localStorage.getItem(STORAGE_KEY);
+
+    if (storedPreference === 'light' || storedPreference === 'dark') {
+      setTheme(storedPreference);
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const syncSystemTheme = (eventOrMediaQuery) => {
+      const matches = eventOrMediaQuery.matches;
+      setSystemTheme(matches ? 'dark' : 'light');
+    };
+
+    syncSystemTheme(mediaQuery);
+
+    const handleChange = (event) => {
+      syncSystemTheme(event);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const resolved = theme === 'system' ? systemTheme : theme;
+
+    root.dataset.theme = resolved;
+
+    if (theme === 'system') {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    }
+  }, [theme, systemTheme]);
+
+  const value = useMemo(() => {
+    const resolvedTheme = theme === 'system' ? systemTheme : theme;
+
+    const toggleTheme = () => {
+      const next = resolvedTheme === 'dark' ? 'light' : 'dark';
+      setTheme(next);
+    };
+
+    return {
+      theme,
+      resolvedTheme,
+      toggleTheme,
+    };
+  }, [theme, systemTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a client-side theme provider that honors system preferences and expose a header toggle
- refresh global typography/colors for light and dark palettes while importing JetBrains Mono and underlined links
- replace structural headings in homepage sections with label styling to keep the requested spacing

## Testing
- not run (Next.js lint command prompts for initial configuration)


------
https://chatgpt.com/codex/tasks/task_e_69005980e63883298d215e0ed84ae574