### PR TITLE
Add SSG writing pages and update link targets

### DIFF
--- a/app/components/home/DigestSection.jsx
+++ b/app/components/home/DigestSection.jsx
@@ -8,7 +8,13 @@ const stats = [
     description: (
       <>
         Consistent readers on{' '}
-        <a href="https://dev.to/meeshbhoombah">dev.to</a>
+        <a
+          href="https://dev.to/meeshbhoombah"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          dev.to
+        </a>
       </>
     ),
   },

--- a/app/components/home/FollowSection.jsx
+++ b/app/components/home/FollowSection.jsx
@@ -13,7 +13,9 @@ export default function FollowSection() {
       <ul>
         {links.map(({ label, href }) => (
           <li key={label}>
-            <a href={href}>{label}</a>
+            <a href={href} target="_blank" rel="noopener noreferrer">
+              {label}
+            </a>
           </li>
         ))}
       </ul>

--- a/app/components/home/OutputsSection.jsx
+++ b/app/components/home/OutputsSection.jsx
@@ -3,7 +3,11 @@ export default function OutputsSection() {
     <section className="home-section" aria-label="Outputs">
       <p className="section-label">Outputs</p>
       <p>
-        <a href="https://meeshbhoombah2020.notion.site/Outputs-25bce498609c4d089bc670ec3dfce8ad">
+        <a
+          href="https://meeshbhoombah2020.notion.site/Outputs-25bce498609c4d089bc670ec3dfce8ad"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Outputs
         </a>
       </p>

--- a/app/components/home/WorkSection.jsx
+++ b/app/components/home/WorkSection.jsx
@@ -12,7 +12,13 @@ const previousRoles = [
           (
             <span>
               A Bitcoin L2 based on{' '}
-              <a href="https://github.com/paradigmxyz/reth/releases/tag/v1.0.5">reth v1.5.0</a>{' '}
+              <a
+                href="https://github.com/paradigmxyz/reth/releases/tag/v1.0.5"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                reth v1.5.0
+              </a>{' '}
               with 10,000,000+ tx &amp; 150,000+ unique addresses
             </span>
           ),
@@ -48,7 +54,13 @@ const previousRoles = [
           (
             <span>
               A private, pipelined, optimized fork of{' '}
-              <a href="https://github.com/dereneaton/ipyrad">ipyrad</a>
+              <a
+                href="https://github.com/dereneaton/ipyrad"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                ipyrad
+              </a>
             </span>
           ),
         ],
@@ -119,7 +131,9 @@ export default function WorkSection() {
         <ul>
           {nowRoles.map(({ name, href }) => (
             <li key={name}>
-              <a href={href}>{name}</a>
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                {name}
+              </a>
             </li>
           ))}
         </ul>
@@ -129,7 +143,9 @@ export default function WorkSection() {
         <ul>
           {previousRoles.map(({ name, href, contributions = [] }) => (
             <li key={name}>
-              <a href={href}>{name}</a>
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                {name}
+              </a>
               {contributions.length > 0 && (
                 <ul>
                   {contributions.map((contribution, index) =>

--- a/app/components/home/WritingSection.jsx
+++ b/app/components/home/WritingSection.jsx
@@ -13,7 +13,13 @@ export default function WritingSection({ sections }) {
             <ul>
               {entries.map(({ title, description, href }) => (
                 <li key={href}>
-                  <a href={`/${href}`}>{title}</a>
+                  <a
+                    href={`/${href}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {title}
+                  </a>
                   {description && <p>{description}</p>}
                 </li>
               ))}

--- a/app/globals.css
+++ b/app/globals.css
@@ -206,6 +206,50 @@ body {
   line-height: 1.7;
 }
 
+.writing-article {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.writing-article h1 {
+  margin: 0;
+  font-size: 2.4rem;
+}
+
+.writing-article-description {
+  margin: 0 0 8px;
+  color: var(--color-muted);
+}
+
+.writing-article-body > * + * {
+  margin-top: 16px;
+}
+
+.writing-article-body h2,
+.writing-article-body h3,
+.writing-article-body h4 {
+  margin: 24px 0 8px;
+}
+
+.writing-article-body ul {
+  margin: 0;
+  padding-left: 1.5rem;
+}
+
+.writing-article-body blockquote {
+  margin: 16px 0;
+  padding-left: 1rem;
+  border-left: 3px solid var(--color-muted);
+}
+
+.writing-article-body code {
+  background-color: rgba(127, 127, 127, 0.12);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.95em;
+}
+
 a {
   color: inherit;
   text-decoration: underline;

--- a/app/lib/markdown.js
+++ b/app/lib/markdown.js
@@ -1,0 +1,213 @@
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function escapeHtmlAttribute(text) {
+  return escapeHtml(text).replace(/'/g, '&#39;');
+}
+
+function processInline(text) {
+  let result = '';
+  let buffer = '';
+
+  const flushBuffer = () => {
+    if (buffer) {
+      result += escapeHtml(buffer);
+      buffer = '';
+    }
+  };
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (char === '`') {
+      const closing = text.indexOf('`', index + 1);
+      if (closing !== -1) {
+        flushBuffer();
+        const code = text.slice(index + 1, closing);
+        result += `<code>${escapeHtml(code)}</code>`;
+        index = closing;
+        continue;
+      }
+    }
+
+    if (char === '[') {
+      const closingBracket = text.indexOf(']', index + 1);
+      const openingParen = text.indexOf('(', closingBracket);
+      const closingParen = text.indexOf(')', openingParen);
+
+      if (
+        closingBracket !== -1 &&
+        openingParen === closingBracket + 1 &&
+        closingParen !== -1
+      ) {
+        const linkText = text.slice(index + 1, closingBracket);
+        const href = text.slice(openingParen + 1, closingParen);
+        flushBuffer();
+        result += `<a href="${escapeHtmlAttribute(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(linkText)}</a>`;
+        index = closingParen;
+        continue;
+      }
+    }
+
+    if (char === '*' || char === '_') {
+      const marker = char;
+      const doubleMarker = marker.repeat(2);
+
+      if (text.slice(index, index + 2) === doubleMarker) {
+        const closing = text.indexOf(doubleMarker, index + 2);
+        if (closing !== -1) {
+          const inner = text.slice(index + 2, closing);
+          flushBuffer();
+          result += `<strong>${processInline(inner)}</strong>`;
+          index = closing + 1;
+          continue;
+        }
+      } else {
+        const closing = text.indexOf(marker, index + 1);
+        if (closing !== -1) {
+          const inner = text.slice(index + 1, closing);
+          flushBuffer();
+          result += `<em>${processInline(inner)}</em>`;
+          index = closing;
+          continue;
+        }
+      }
+    }
+
+    buffer += char;
+  }
+
+  flushBuffer();
+  return result;
+}
+
+function flushParagraphsFromLines(lines, htmlParts) {
+  let paragraphLines = [];
+
+  const flush = () => {
+    if (paragraphLines.length === 0) {
+      return;
+    }
+
+    const paragraph = paragraphLines.join(' ').trim();
+    if (paragraph) {
+      htmlParts.push(`<p>${processInline(paragraph)}</p>`);
+    }
+    paragraphLines = [];
+  };
+
+  for (const line of lines) {
+    if (!line.trim()) {
+      flush();
+    } else {
+      paragraphLines.push(line.trim());
+    }
+  }
+
+  flush();
+}
+
+export function renderMarkdownToHtml(markdown) {
+  const normalized = markdown.replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n');
+  const htmlParts = [];
+
+  let paragraphBuffer = [];
+  let inList = false;
+  let inBlockquote = false;
+  let blockquoteLines = [];
+
+  const flushParagraph = () => {
+    if (paragraphBuffer.length === 0) {
+      return;
+    }
+    const paragraph = paragraphBuffer.join(' ').trim();
+    if (paragraph) {
+      htmlParts.push(`<p>${processInline(paragraph)}</p>`);
+    }
+    paragraphBuffer = [];
+  };
+
+  const closeList = () => {
+    if (inList) {
+      htmlParts.push('</ul>');
+      inList = false;
+    }
+  };
+
+  const flushBlockquote = () => {
+    if (!inBlockquote) {
+      return;
+    }
+
+    htmlParts.push('<blockquote>');
+    flushParagraphsFromLines(blockquoteLines, htmlParts);
+    htmlParts.push('</blockquote>');
+    blockquoteLines = [];
+    inBlockquote = false;
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      flushParagraph();
+      closeList();
+      flushBlockquote();
+      continue;
+    }
+
+    const headingMatch = trimmed.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      flushParagraph();
+      closeList();
+      flushBlockquote();
+
+      const level = headingMatch[1].length;
+      const text = headingMatch[2].trim();
+      htmlParts.push(`<h${level}>${processInline(text)}</h${level}>`);
+      continue;
+    }
+
+    const blockquoteMatch = line.match(/^>\s?(.*)$/);
+    if (blockquoteMatch) {
+      flushParagraph();
+      closeList();
+      if (!inBlockquote) {
+        inBlockquote = true;
+        blockquoteLines = [];
+      }
+      blockquoteLines.push(blockquoteMatch[1]);
+      continue;
+    }
+
+    if (inBlockquote) {
+      flushBlockquote();
+    }
+
+    const listMatch = trimmed.match(/^[-*]\s+(.*)$/);
+    if (listMatch) {
+      flushParagraph();
+      if (!inList) {
+        htmlParts.push('<ul>');
+        inList = true;
+      }
+      htmlParts.push(`<li>${processInline(listMatch[1].trim())}</li>`);
+      continue;
+    }
+
+    closeList();
+    paragraphBuffer.push(trimmed);
+  }
+
+  flushParagraph();
+  closeList();
+  flushBlockquote();
+
+  return htmlParts.join('');
+}

--- a/app/writing/[category]/[slug]/page.jsx
+++ b/app/writing/[category]/[slug]/page.jsx
@@ -1,0 +1,52 @@
+import { notFound } from 'next/navigation';
+
+import {
+  getLiveWritingStaticParams,
+  getWritingEntry,
+  WRITING_CATEGORY_LABELS,
+} from '../../../lib/writing';
+import { renderMarkdownToHtml } from '../../../lib/markdown';
+
+export function generateStaticParams() {
+  return getLiveWritingStaticParams();
+}
+
+export function generateMetadata({ params }) {
+  const entry = getWritingEntry(params.category, params.slug);
+
+  if (!entry || entry.status !== 'live') {
+    return {};
+  }
+
+  return {
+    title: `${entry.title} · ${WRITING_CATEGORY_LABELS[entry.category] || 'Writing'}`,
+    description: entry.description || undefined,
+  };
+}
+
+export default function WritingArticlePage({ params }) {
+  const entry = getWritingEntry(params.category, params.slug);
+
+  if (!entry || entry.status !== 'live') {
+    notFound();
+  }
+
+  const html = renderMarkdownToHtml(entry.content);
+  const categoryLabel = WRITING_CATEGORY_LABELS[entry.category] || 'Writing';
+
+  return (
+    <main className="content">
+      <article className="markdown writing-article" aria-labelledby="writing-article-title">
+        <p className="section-label">{categoryLabel}</p>
+        <h1 id="writing-article-title">{entry.title}</h1>
+        {entry.description ? (
+          <p className="writing-article-description">{entry.description}</p>
+        ) : null}
+        <div
+          className="writing-article-body"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </article>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple markdown renderer and static /writing/[category]/[slug] page to surface content from the writing directory
- reuse the writing library to expose static params and feed the home page with rendered URLs
- update global styles and all homepage links so that they open in a new tab and improve article presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69006baa9e9c8329be20194143d3ad83