### PR TITLE
Prevent duplicate title rendering on article pages

### DIFF
--- a/app/lib/markdown.js
+++ b/app/lib/markdown.js
@@ -112,7 +112,12 @@ function flushParagraphsFromLines(lines, htmlParts) {
   flush();
 }
 
-export function renderMarkdownToHtml(markdown) {
+function normalizeHeadingText(value) {
+  return value.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+export function renderMarkdownToHtml(markdown, options = {}) {
+  const { stripHeading } = options;
   const normalized = markdown.replace(/\r\n/g, '\n');
   const lines = normalized.split('\n');
   const htmlParts = [];
@@ -121,6 +126,7 @@ export function renderMarkdownToHtml(markdown) {
   let inList = false;
   let inBlockquote = false;
   let blockquoteLines = [];
+  let headingStripped = false;
 
   const flushParagraph = () => {
     if (paragraphBuffer.length === 0) {
@@ -170,6 +176,16 @@ export function renderMarkdownToHtml(markdown) {
 
       const level = headingMatch[1].length;
       const text = headingMatch[2].trim();
+      if (
+        !headingStripped &&
+        stripHeading &&
+        (stripHeading === true ||
+          (typeof stripHeading === 'string' &&
+            normalizeHeadingText(text) === normalizeHeadingText(stripHeading)))
+      ) {
+        headingStripped = true;
+        continue;
+      }
       htmlParts.push(`<h${level}>${processInline(text)}</h${level}>`);
       continue;
     }

--- a/app/writing/[category]/[slug]/page.jsx
+++ b/app/writing/[category]/[slug]/page.jsx
@@ -31,7 +31,7 @@ export default function WritingArticlePage({ params }) {
     notFound();
   }
 
-  const html = renderMarkdownToHtml(entry.content);
+  const html = renderMarkdownToHtml(entry.content, { stripHeading: entry.title });
   const categoryLabel = WRITING_CATEGORY_LABELS[entry.category] || 'Writing';
 
   return (


### PR DESCRIPTION
## Summary
- skip the leading markdown heading when it matches the article title so the page header is not duplicated
- pass the title to the markdown renderer when displaying articles

## Testing
- npm run lint *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6900700440f483298aa38e4ffb4e8e49