### PR TITLE
Adjust digest dev.to line break responsiveness

### DIFF
--- a/app/components/home/DigestSection.jsx
+++ b/app/components/home/DigestSection.jsx
@@ -6,8 +6,9 @@ const stats = [
   {
     value: '~700',
     description: (
-      <>
-        Consistent readers on{' '}
+      <span className="digest-devto">
+        Consistent readers on
+        <br className="digest-devto__break" />{' '}
         <a
           href="https://dev.to/meeshbhoombah"
           target="_blank"
@@ -15,7 +16,7 @@ const stats = [
         >
           dev.to
         </a>
-      </>
+      </span>
     ),
   },
   {

--- a/app/globals.css
+++ b/app/globals.css
@@ -163,6 +163,20 @@ body {
   gap: 0;
 }
 
+.digest-devto {
+  display: inline;
+}
+
+@media (max-width: 600px) {
+  .digest-devto {
+    white-space: nowrap;
+  }
+
+  .digest-devto__break {
+    display: none;
+  }
+}
+
 .stat-value {
   margin: 0;
   font-size: 1.4rem;


### PR DESCRIPTION
## Summary
- wrap the digest dev.to statistic with a span to control line breaking
- add responsive styling so the link drops to a new line on larger screens but stays inline on mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900759b3d0883299212a819f37b8b0a