### PR TITLE
Refine WakaTime charts presentation

### DIFF
--- a/app/components/home/WorkSection.jsx
+++ b/app/components/home/WorkSection.jsx
@@ -1,4 +1,11 @@
-import { isValidElement } from 'react';
+"use client";
+
+import { isValidElement, useEffect, useMemo, useState } from 'react';
+
+const activityUrl =
+  'https://wakatime.com/share/@Meeshbhoombah/6d82282c-df01-46bf-b408-7b359f933419.json';
+const languagesUrl =
+  'https://wakatime.com/share/@Meeshbhoombah/8c7ee140-809e-4f98-bd17-3d553ec2bd75.json';
 
 const previousRoles = [
   {
@@ -99,6 +106,84 @@ const nowRoles = [
   },
 ];
 
+function formatDuration(totalSeconds) {
+  if (!totalSeconds) {
+    return '0m';
+  }
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.round((totalSeconds % 3600) / 60);
+
+  const parts = [];
+  if (hours) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes || parts.length === 0) {
+    parts.push(`${minutes}m`);
+  }
+
+  return parts.join(' ');
+}
+
+function getWeekdayLabel(dateString) {
+  try {
+    const date = new Date(dateString);
+    return new Intl.DateTimeFormat('en-US', {
+      weekday: 'short',
+    }).format(date);
+  } catch (error) {
+    return dateString;
+  }
+}
+
+function normalizeActivityData(data) {
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data
+    .map((entry) => {
+      const totalSeconds = entry?.grand_total?.total_seconds ?? 0;
+      const label = getWeekdayLabel(entry?.range?.date);
+      return {
+        label,
+        totalSeconds,
+        displayValue: formatDuration(totalSeconds),
+      };
+    })
+    .filter((entry) => entry.label);
+}
+
+function normalizeLanguageData(data) {
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  const trimmed = data
+    .map((entry) => ({
+      name: entry?.name ?? 'Unknown',
+      percent: entry?.percent ?? 0,
+      color: entry?.color ?? 'var(--color-muted)',
+    }))
+    .filter((entry) => entry.percent > 0)
+    .slice(0, 8);
+
+  if (!trimmed.length) {
+    return [];
+  }
+
+  const totalPercent = trimmed.reduce((sum, entry) => sum + entry.percent, 0);
+
+  if (totalPercent <= 0) {
+    return [];
+  }
+
+  return trimmed.map((entry) => ({
+    ...entry,
+    percent: (entry.percent / totalPercent) * 100,
+  }));
+}
+
 function renderContribution(contribution, keyPrefix) {
   if (typeof contribution === 'string') {
     return <li key={`${keyPrefix}-text`}>{contribution}</li>;
@@ -123,6 +208,72 @@ function renderContribution(contribution, keyPrefix) {
 }
 
 export default function WorkSection() {
+  const [activityData, setActivityData] = useState([]);
+  const [languagesData, setLanguagesData] = useState([]);
+  const [activityLoading, setActivityLoading] = useState(true);
+  const [languagesLoading, setLanguagesLoading] = useState(true);
+  const [activityError, setActivityError] = useState(false);
+  const [languagesError, setLanguagesError] = useState(false);
+  const [hoveredLanguage, setHoveredLanguage] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchActivity = async () => {
+      try {
+        const response = await fetch(activityUrl);
+        const json = await response.json();
+        if (isMounted) {
+          setActivityData(normalizeActivityData(json?.data));
+          setActivityLoading(false);
+        }
+      } catch (error) {
+        if (isMounted) {
+          setActivityError(true);
+          setActivityLoading(false);
+        }
+      }
+    };
+
+    const fetchLanguages = async () => {
+      try {
+        const response = await fetch(languagesUrl);
+        const json = await response.json();
+        if (isMounted) {
+          setLanguagesData(normalizeLanguageData(json?.data));
+          setLanguagesLoading(false);
+        }
+      } catch (error) {
+        if (isMounted) {
+          setLanguagesError(true);
+          setLanguagesLoading(false);
+        }
+      }
+    };
+
+    fetchActivity();
+    fetchLanguages();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    setHoveredLanguage(null);
+  }, [languagesData]);
+
+  const maxActivitySeconds = useMemo(() => {
+    if (!activityData.length) {
+      return 0;
+    }
+
+    return activityData.reduce(
+      (max, entry) => Math.max(max, entry.totalSeconds ?? 0),
+      0,
+    );
+  }, [activityData]);
+
   return (
     <section className="home-section" aria-label="Work">
       <p className="section-label">Work</p>
@@ -137,6 +288,117 @@ export default function WorkSection() {
             </li>
           ))}
         </ul>
+      </div>
+      <div className="work-activity-charts">
+        <div className="work-chart-card">
+          <p className="subsection-label work-chart-title">Last 7 Days of Coding Activity</p>
+          {activityLoading ? (
+            <p className="work-chart-message">Loading activity…</p>
+          ) : activityError ? (
+            <p className="work-chart-message" role="alert">
+              Unable to load coding activity right now.
+            </p>
+          ) : activityData.length === 0 ? (
+            <p className="work-chart-message">No recent coding activity recorded.</p>
+          ) : (
+            <div
+              className="work-bar-chart"
+              role="list"
+              aria-label="Coding activity for the last seven days"
+            >
+              {activityData.map(({ label, totalSeconds, displayValue }) => {
+                const height = maxActivitySeconds
+                  ? Math.max((totalSeconds / maxActivitySeconds) * 100, 4)
+                  : 4;
+                return (
+                  <div className="work-bar-chart__item" key={label} role="listitem">
+                    <div className="work-bar-chart__column">
+                      <div
+                        className="work-bar-chart__bar"
+                        style={{ height: `${height}%` }}
+                        data-value={displayValue}
+                        tabIndex={0}
+                        aria-label={`${label}: ${displayValue}`}
+                      />
+                      <span className="sr-only">Time spent: {displayValue}</span>
+                    </div>
+                    <span className="work-bar-chart__label">{label}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <div className="work-chart-card">
+          <p className="subsection-label work-chart-title">Languages Used (Last 30 Days)</p>
+          {languagesLoading ? (
+            <p className="work-chart-message">Loading languages…</p>
+          ) : languagesError ? (
+            <p className="work-chart-message" role="alert">
+              Unable to load languages right now.
+            </p>
+          ) : languagesData.length === 0 ? (
+            <p className="work-chart-message">No language data available.</p>
+          ) : (
+            <div className="work-donut-chart">
+              <svg
+                className="work-donut-chart__svg"
+                viewBox="0 0 120 120"
+                role="img"
+                aria-label="Language usage for the past thirty days"
+              >
+                <title>Language usage for the past thirty days</title>
+                {(() => {
+                  const radius = 50;
+                  const circumference = 2 * Math.PI * radius;
+                  let cumulativePercent = 0;
+
+                  return languagesData.map((language, index) => {
+                    const { name, percent, color } = language;
+                    const startPercent = cumulativePercent;
+                    cumulativePercent += percent;
+                    const dash = Math.max((percent / 100) * circumference, 0);
+                    const gap = Math.max(circumference - dash, 0);
+
+                    return (
+                      <circle
+                        key={`${name}-${index}`}
+                        className="work-donut-chart__segment"
+                        cx="60"
+                        cy="60"
+                        r={radius}
+                        fill="transparent"
+                        stroke={color}
+                        strokeWidth="20"
+                        strokeDasharray={`${dash} ${gap}`}
+                        strokeDashoffset={circumference * (1 - startPercent / 100)}
+                        transform="rotate(-90 60 60)"
+                        tabIndex={0}
+                        aria-label={`${name}: ${percent.toFixed(1)} percent`}
+                        onMouseEnter={() => setHoveredLanguage(language)}
+                        onMouseLeave={() => setHoveredLanguage(null)}
+                        onFocus={() => setHoveredLanguage(language)}
+                        onBlur={() => setHoveredLanguage(null)}
+                      />
+                    );
+                  });
+                })()}
+              </svg>
+              <div className="work-donut-chart__center" aria-live="polite">
+                {hoveredLanguage && (
+                  <>
+                    <span className="work-donut-chart__center-name">
+                      {hoveredLanguage.name}
+                    </span>
+                    <span className="work-donut-chart__center-value">
+                      {hoveredLanguage.percent.toFixed(1)}%
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
       <div className="home-subsection">
         <p className="subsection-label">Previously</p>

--- a/app/components/home/WorkSection.jsx
+++ b/app/components/home/WorkSection.jsx
@@ -330,7 +330,9 @@ export default function WorkSection() {
           )}
         </div>
         <div className="work-chart-card">
-          <p className="subsection-label work-chart-title">Languages Used (Last 30 Days)</p>
+          <p className="subsection-label work-chart-title work-chart-title--right">
+            Languages Used (Last 30 Days)
+          </p>
           {languagesLoading ? (
             <p className="work-chart-message">Loading languages…</p>
           ) : languagesError ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -229,6 +229,11 @@ body {
   letter-spacing: 0.1em;
 }
 
+.work-chart-title--right {
+  align-self: flex-end;
+  text-align: right;
+}
+
 .work-chart-message {
   margin: 0;
   font-size: 0.9rem;

--- a/app/globals.css
+++ b/app/globals.css
@@ -199,6 +199,191 @@ body {
   margin-top: 8px;
 }
 
+.work-activity-charts {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-left: -1.4rem;
+  max-width: calc(100% + 1.4rem);
+}
+
+@media (max-width: 860px) {
+  .work-activity-charts {
+    grid-template-columns: 1fr;
+    margin-left: 0;
+    max-width: 100%;
+  }
+}
+
+.work-chart-card {
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: color-mix(in srgb, var(--color-background) 92%, transparent);
+}
+
+.work-chart-title {
+  font-size: 0.48rem;
+  letter-spacing: 0.1em;
+}
+
+.work-chart-message {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.work-bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  height: 180px;
+}
+
+.work-bar-chart__item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  height: 100%;
+}
+
+.work-bar-chart__column {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  height: 100%;
+}
+
+.work-bar-chart__bar {
+  width: 100%;
+  position: relative;
+  background: #000000;
+  transition: height 0.3s ease;
+  min-height: 8px;
+  outline: none;
+}
+
+.work-bar-chart__bar::after {
+  content: attr(data-value);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translate(-50%, 0);
+  background: var(--color-foreground);
+  color: var(--color-background);
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.work-bar-chart__bar::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 100%;
+  transform: translate(-50%, 0);
+  border: 6px solid transparent;
+  border-top-color: var(--color-foreground);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.work-bar-chart__bar:hover::after,
+.work-bar-chart__bar:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, -6px);
+}
+
+.work-bar-chart__bar:hover::before,
+.work-bar-chart__bar:focus-visible::before {
+  opacity: 1;
+}
+
+.work-bar-chart__bar:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-foreground) 40%, transparent);
+}
+
+.work-bar-chart__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  min-height: 1.1rem;
+}
+
+.work-donut-chart {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.work-donut-chart__svg {
+  width: 160px;
+  height: 160px;
+}
+
+.work-donut-chart__segment {
+  stroke-linecap: butt;
+  cursor: pointer;
+}
+
+.work-donut-chart__center {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  text-align: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.work-donut-chart__center-name {
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.work-donut-chart__center-value {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.work-donut-chart__segment:focus-visible {
+  outline: none;
+  stroke-width: 22;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .home-digest-item p + p {
   margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- left-align the WakaTime chart group with the Now header and shrink the chart titles further
- show daily totals from the bar chart in hover/focus tooltips while keeping bars square and uncluttered
- thicken the donut segments and limit the center readout to the active slice only

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_69007d69cda483299f3d2985844a5b55