### PR TITLE
Show dominant language in donut chart center

### DIFF
--- a/app/components/home/WorkSection.jsx
+++ b/app/components/home/WorkSection.jsx
@@ -263,6 +263,22 @@ export default function WorkSection() {
     setHoveredLanguage(null);
   }, [languagesData]);
 
+  const topLanguage = useMemo(() => {
+    if (!languagesData.length) {
+      return null;
+    }
+
+    return languagesData.reduce((currentTop, language) => {
+      if (!currentTop || (language.percent ?? 0) > (currentTop.percent ?? 0)) {
+        return language;
+      }
+
+      return currentTop;
+    }, null);
+  }, [languagesData]);
+
+  const activeLanguage = hoveredLanguage ?? topLanguage;
+
   const maxActivitySeconds = useMemo(() => {
     if (!activityData.length) {
       return 0;
@@ -387,13 +403,13 @@ export default function WorkSection() {
                 })()}
               </svg>
               <div className="work-donut-chart__center" aria-live="polite">
-                {hoveredLanguage && (
+                {activeLanguage && (
                   <>
                     <span className="work-donut-chart__center-name">
-                      {hoveredLanguage.name}
+                      {activeLanguage.name}
                     </span>
                     <span className="work-donut-chart__center-value">
-                      {hoveredLanguage.percent.toFixed(1)}%
+                      {activeLanguage.percent.toFixed(1)}%
                     </span>
                   </>
                 )}


### PR DESCRIPTION
## Summary
- compute the dominant language from the fetched Wakatime data
- display the dominant language in the donut chart center when nothing is hovered
- keep the hovered language display behavior when a segment is focused or hovered

## Testing
- `npm run lint` *(fails: requires interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_69008d2557148329b843d9b1d28e9905