### PR TITLE
Align mobile work charts with Now label

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -278,7 +278,7 @@ body {
 .work-bar-chart__bar {
   width: 100%;
   position: relative;
-  background: #000000;
+  background: var(--color-foreground);
   transition: height 0.3s ease;
   min-height: 8px;
   outline: none;
@@ -383,6 +383,21 @@ body {
 .work-donut-chart__segment:focus-visible {
   outline: none;
   stroke-width: 22;
+}
+
+@media (max-width: 600px) {
+  .work-chart-card {
+    padding: 20px 0;
+  }
+
+  .work-chart-title--right {
+    align-self: flex-start;
+    text-align: left;
+  }
+
+  .work-donut-chart {
+    justify-content: flex-start;
+  }
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- align the Work section chart cards with the "Now" subsection on narrow viewports and left-align the donut chart
- switch the bar chart fill to the theme foreground color so bars turn white in dark mode

## Testing
- npm run dev *(fails to load external feeds because the environment has no network access)*

------
https://chatgpt.com/codex/tasks/task_e_69008f0640c883299aac78661cf9b324