### PR TITLE
Hide local writing descriptions on homepage

### DIFF
--- a/app/components/home/WritingSection.jsx
+++ b/app/components/home/WritingSection.jsx
@@ -17,6 +17,7 @@ export default function WritingSection({ sections }) {
               <ul>
                 {entries.map(({ title, description, href }) => {
                   const isExternal = /^https?:\/\//i.test(href);
+                  const isLocalWriting = !isExternal && /^writing\//i.test(href);
                   const linkHref = isExternal ? href : `/${href}`;
 
                   return (
@@ -32,7 +33,7 @@ export default function WritingSection({ sections }) {
                       >
                         {title}
                       </a>
-                      {description && <p>{description}</p>}
+                      {description && !isLocalWriting && <p>{description}</p>}
                     </li>
                   );
                 })}


### PR DESCRIPTION
## Summary
- update the homepage writing list to detect internal `/writing` entries
- suppress descriptions for locally hosted articles while preserving external summaries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6900927346a48329837cf476d625fb2a