### PR TITLE
Use emoji icons for theme toggle button

### DIFF
--- a/app/components/ThemeToggle.jsx
+++ b/app/components/ThemeToggle.jsx
@@ -4,16 +4,17 @@ import { useTheme } from '../theme-provider';
 
 export default function ThemeToggle() {
   const { resolvedTheme, toggleTheme } = useTheme();
-  const nextMode = resolvedTheme === 'dark' ? 'Light' : 'Dark';
+  const nextMode = resolvedTheme === 'dark' ? 'light' : 'dark';
+  const nextModeEmoji = nextMode === 'dark' ? '🌗' : '🌓';
 
   return (
     <button
       type="button"
       className="theme-toggle"
       onClick={toggleTheme}
-      aria-label={`Switch to ${nextMode.toLowerCase()} mode`}
+      aria-label={`Switch to ${nextMode} mode`}
     >
-      {nextMode} mode
+      {nextModeEmoji}
     </button>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -81,21 +81,19 @@ body {
 
 .theme-toggle {
   appearance: none;
-  border: 1px solid var(--color-muted);
+  border: none;
   background: transparent;
   color: inherit;
-  padding: 0.4rem 0.8rem;
+  padding: 0.4rem;
   border-radius: 999px;
-  font-size: 0.85rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  font-size: 1.2rem;
   cursor: pointer;
 }
 
 .theme-toggle:hover,
 .theme-toggle:focus-visible {
-  border-color: var(--color-muted-strong);
-  outline: none;
+  outline: 2px solid var(--color-muted-strong);
+  outline-offset: 2px;
 }
 
 .content {


### PR DESCRIPTION
## Summary
- replace the theme toggle label with mode-specific emoji icons for clarity
- update button styling to remove the border while keeping a visible focus outline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690092a8b0e48329ab189b4ee813b532