### PR TITLE
Adjust site branding text

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -15,12 +15,12 @@ export default function RootLayout({ children }) {
         <ThemeProvider>
           <div className="page-container">
             <header className="page-header">
-              <span className="site-title">Meeshbhoombah.</span>
+              <span className="site-title">Meeshbhoombah</span>
               <ThemeToggle />
             </header>
             {children}
             <footer className="page-footer">
-              <span>© {new Date().getFullYear()} Meesh Bhoombah</span>
+              <span>© {new Date().getFullYear()} Meeshbhoombah</span>
             </footer>
           </div>
         </ThemeProvider>


### PR DESCRIPTION
## Summary
- remove the trailing period from the header site title
- update the footer attribution to use the continuous Meeshbhoombah name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690092dabbf0832994f16e8aaa66dcec