### PR TITLE
Fix mobile donut chart center alignment

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -368,6 +368,9 @@ body {
   height: 72px;
   border-radius: 50%;
   pointer-events: none;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .work-donut-chart__center-name {


### PR DESCRIPTION
## Summary
- center the donut chart label by anchoring it to the middle of the chart container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900939c28a48329939e5a9d5e345282