### PR TITLE
Swap theme toggle emoji and refine hover styling

### DIFF
--- a/app/components/ThemeToggle.jsx
+++ b/app/components/ThemeToggle.jsx
@@ -5,7 +5,7 @@ import { useTheme } from '../theme-provider';
 export default function ThemeToggle() {
   const { resolvedTheme, toggleTheme } = useTheme();
   const nextMode = resolvedTheme === 'dark' ? 'light' : 'dark';
-  const nextModeEmoji = nextMode === 'dark' ? '🌗' : '🌓';
+  const nextModeEmoji = nextMode === 'dark' ? '🌓' : '🌗';
 
   return (
     <button

--- a/app/globals.css
+++ b/app/globals.css
@@ -92,8 +92,8 @@ body {
 
 .theme-toggle:hover,
 .theme-toggle:focus-visible {
-  outline: 2px solid var(--color-muted-strong);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-muted-strong);
 }
 
 .content {


### PR DESCRIPTION
## Summary
- swap the theme toggle icons so the dark-mode moon is shown while in light mode and vice versa
- replace the outline hover effect with a box shadow to avoid aliasing while preserving focus visibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69009505b5c083299f6eb0343b11fba8