### PR TITLE
Adjust donut chart percentage positioning on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -399,6 +399,16 @@ body {
   .work-donut-chart {
     justify-content: flex-start;
   }
+
+  .work-donut-chart__center {
+    position: static;
+    transform: none;
+    margin-left: 16px;
+    width: auto;
+    height: auto;
+    align-items: flex-start;
+    text-align: left;
+  }
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- adjust the donut chart center label positioning on small screens
- move the percentage label next to the donut with spacing for mobile layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690095b2d258832982961b5c75e10d24