### PR TITLE
Keep header alignment consistent on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -84,16 +84,23 @@ body {
   border: none;
   background: transparent;
   color: inherit;
-  padding: 0.4rem;
+  padding: 0.3rem;
   border-radius: 999px;
   font-size: 1.2rem;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 
-.theme-toggle:hover,
-.theme-toggle:focus-visible {
+.theme-toggle:hover {
   outline: none;
-  box-shadow: 0 0 0 2px var(--color-muted-strong);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--color-muted-strong);
+  outline-offset: 2px;
 }
 
 .content {
@@ -509,15 +516,14 @@ a:focus-visible {
     grid-template-columns: 1fr;
   }
 
-  .page-header,
   .page-footer {
     flex-direction: column;
     align-items: flex-start;
     gap: 12px;
   }
 
-  .theme-toggle {
-    align-self: flex-end;
+  .page-header {
+    gap: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the header layout horizontal on mobile so the site title and theme toggle stay aligned
- limit the mobile flex-column override to the footer to avoid shifting the header controls

## Testing
- Not run (npm run lint prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_6900980a7a788329947857ca0e380fb6