### PR TITLE
Add top language summary to work donut chart

### DIFF
--- a/app/components/home/WorkSection.jsx
+++ b/app/components/home/WorkSection.jsx
@@ -263,6 +263,16 @@ export default function WorkSection() {
     setHoveredLanguage(null);
   }, [languagesData]);
 
+  const topLanguages = useMemo(() => {
+    if (!languagesData.length) {
+      return [];
+    }
+
+    return [...languagesData]
+      .sort((a, b) => (b.percent ?? 0) - (a.percent ?? 0))
+      .slice(0, 3);
+  }, [languagesData]);
+
   const topLanguage = useMemo(() => {
     if (!languagesData.length) {
       return null;
@@ -414,6 +424,26 @@ export default function WorkSection() {
                   </>
                 )}
               </div>
+              {topLanguages.length > 0 && (
+                <ul className="work-donut-chart__summary" aria-label="Top three languages">
+                  {topLanguages.map(({ name, percent, color }) => (
+                    <li
+                      className="work-donut-chart__summary-item"
+                      key={`${name}-${percent.toFixed(1)}`}
+                    >
+                      <span
+                        className="work-donut-chart__summary-color"
+                        style={{ backgroundColor: color }}
+                        aria-hidden="true"
+                      />
+                      <span className="work-donut-chart__summary-name">{name}</span>
+                      <span className="work-donut-chart__summary-value">
+                        {percent.toFixed(1)}%
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
           )}
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -358,6 +358,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 24px;
 }
 
 .work-donut-chart__svg {
@@ -368,6 +369,41 @@ body {
 .work-donut-chart__segment {
   stroke-linecap: butt;
   cursor: pointer;
+}
+
+.work-donut-chart__summary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  margin-left: 8px;
+  padding: 0;
+  list-style: none;
+  text-align: right;
+}
+
+.work-donut-chart__summary-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.work-donut-chart__summary-color {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.work-donut-chart__summary-name {
+  font-weight: 600;
+  color: var(--color-foreground);
+}
+
+.work-donut-chart__summary-value {
+  min-width: 3.5ch;
 }
 
 .work-donut-chart__center {
@@ -414,6 +450,8 @@ body {
 
   .work-donut-chart {
     justify-content: flex-start;
+    align-items: flex-start;
+    flex-wrap: wrap;
   }
 
   .work-donut-chart__center {
@@ -424,6 +462,13 @@ body {
     height: auto;
     align-items: flex-start;
     text-align: left;
+  }
+
+  .work-donut-chart__summary {
+    align-items: flex-start;
+    text-align: left;
+    margin-left: 0;
+    margin-top: 16px;
   }
 }
 


### PR DESCRIPTION
## Summary
- compute the top three languages from the WakaTime data and display them alongside the donut chart
- add styling for the language summary so it aligns to the right of the chart with responsive tweaks for small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69010bc855208329b39f2095b6a76aab