### PR TITLE
Remove underlines from writing section links

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -163,6 +163,12 @@ body {
   gap: 4px;
 }
 
+.home-writing-entry a,
+.home-writing-entry a:hover,
+.home-writing-entry a:focus-visible {
+  text-decoration: none;
+}
+
 .home-writing-entry p {
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- update the writing section link styles so they no longer render with underlines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69010d8660f4832981fe9fdc21c4474f