### PR TITLE
Add link icon to home writing section entries

### DIFF
--- a/app/components/home/WritingSection.jsx
+++ b/app/components/home/WritingSection.jsx
@@ -30,7 +30,10 @@ export default function WritingSection({ sections }) {
                           }
                         : {})}
                     >
-                      {title}
+                      <span aria-hidden className="home-writing-entry__icon">
+                        🔗
+                      </span>
+                      <span>{title}</span>
                     </a>
                     {description && !isLocalWriting && <p>{description}</p>}
                   </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -169,6 +169,19 @@ body {
   text-decoration: none;
 }
 
+.home-writing-entry a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+}
+
+.home-writing-entry__icon {
+  font-size: 0.85em;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}
+
 .home-writing-entry p {
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- prefix each writing entry link with a decorative link icon
- style the icon to sit inline with the link text at a smaller size for visual balance

## Testing
- npm run dev *(fails: fetch failed with ENETUNREACH when loading external RSS feeds)*

------
https://chatgpt.com/codex/tasks/task_e_690113c5a5508329973158648a3ef012