### PR TITLE
Reduce home writing link icon size

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -176,7 +176,7 @@ body {
 }
 
 .home-writing-entry__icon {
-  font-size: 0.85em;
+  font-size: 0.5em;
   line-height: 1;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- shrink the writing section link icon to half its previous size to make emojis appear smaller while staying aligned with text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69011703e0d4832993026d8254c9a7cd