### PR TITLE
Reduce donut chart summary font size

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -405,7 +405,7 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 0.75rem;
+  font-size: 0.375rem;
   color: var(--color-muted);
 }
 


### PR DESCRIPTION
## Summary
- halve the font size used for the donut chart summary items so the top three languages display smaller

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690117fd619c8329bdb57ac72173cae6