### PR TITLE
Restore writing link styling and show article intros

### DIFF
--- a/app/components/home/WritingSection.jsx
+++ b/app/components/home/WritingSection.jsx
@@ -14,9 +14,8 @@ export default function WritingSection({ sections }) {
           <div className={categoryClassName} key={label}>
             <p className="subsection-label">{label}</p>
             {hasEntries ? (
-              entries.map(({ title, description, href }) => {
+              entries.map(({ title, href, preview }) => {
                 const isExternal = /^https?:\/\//i.test(href);
-                const isLocalWriting = !isExternal && /^writing\//i.test(href);
                 const linkHref = isExternal ? href : `/${href}`;
 
                 return (
@@ -30,12 +29,9 @@ export default function WritingSection({ sections }) {
                           }
                         : {})}
                     >
-                      <span aria-hidden className="home-writing-entry__icon">
-                        🔗
-                      </span>
-                      <span>{title}</span>
+                      {title}
                     </a>
-                    {description && !isLocalWriting && <p>{description}</p>}
+                    {preview && <p>{preview}</p>}
                   </div>
                 );
               })

--- a/app/globals.css
+++ b/app/globals.css
@@ -166,20 +166,11 @@ body {
 .home-writing-entry a,
 .home-writing-entry a:hover,
 .home-writing-entry a:focus-visible {
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .home-writing-entry a {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4em;
-}
-
-.home-writing-entry__icon {
-  font-size: 0.5em;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
+  display: inline;
 }
 
 .home-writing-entry p {

--- a/app/lib/rss.js
+++ b/app/lib/rss.js
@@ -1,3 +1,5 @@
+import { extractFirstSentenceFromText } from './text.js';
+
 const FEED_URLS = [
   'https://dev.to/feed/meeshbhoombah',
   'https://medium.com/feed/@meeshbhoombah',
@@ -232,6 +234,8 @@ export async function getExternalWritingEntries() {
 
       const publishedAtMs = parseDateToMs(item.publishedAt);
 
+      const preview = extractFirstSentenceFromText(item.description);
+
       return {
         title: item.title,
         description: null,
@@ -239,6 +243,7 @@ export async function getExternalWritingEntries() {
         category,
         publishedAtMs,
         source: 'external',
+        preview,
       };
     });
 }

--- a/app/lib/text.js
+++ b/app/lib/text.js
@@ -1,0 +1,108 @@
+const HTML_ENTITIES = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+};
+
+function decodeHtmlEntities(value) {
+  if (!value) return '';
+  return value.replace(/&(amp|lt|gt|quot|#39);/gi, (match) => {
+    const decoded = HTML_ENTITIES[match.toLowerCase()];
+    return typeof decoded === 'string' ? decoded : match;
+  });
+}
+
+function stripInlineMarkdown(value) {
+  if (!value) return '';
+
+  let text = value;
+
+  text = text.replace(/`([^`]+)`/g, '$1');
+  text = text.replace(/~~([^~]+)~~/g, '$1');
+  text = text.replace(/(\*\*|__)(.*?)\1/g, '$2');
+  text = text.replace(/(\*|_)(.*?)\1/g, '$2');
+  text = text.replace(/!\[[^\]]*?\]\([^)]*?\)/g, '');
+  text = text.replace(/\[([^\]]+?)\]\([^)]*?\)/g, '$1');
+  text = text.replace(/<[^>]*>/g, '');
+  text = text.replace(/\\([\\`*_{}\[\]()#+\-.!>])/g, '$1');
+  text = text.replace(/&nbsp;/gi, ' ');
+  text = decodeHtmlEntities(text);
+
+  return text;
+}
+
+export function extractFirstSentenceFromText(text) {
+  if (!text) return '';
+
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (!normalized) {
+    return '';
+  }
+
+  const sentenceMatch = normalized.match(/^(.+?[.!?])(?=\s|$)/);
+  if (sentenceMatch) {
+    return sentenceMatch[1].trim();
+  }
+
+  return normalized;
+}
+
+export function extractFirstSentenceFromMarkdown(markdown) {
+  if (!markdown) return '';
+
+  const lines = markdown.split(/\r?\n/);
+  let paragraphLines = [];
+
+  function processParagraph() {
+    if (paragraphLines.length === 0) {
+      return '';
+    }
+
+    const combined = paragraphLines.join(' ');
+    const stripped = stripInlineMarkdown(combined)
+      .replace(/^\s*>+\s*/g, '')
+      .replace(/^\s*[-*+]\s+/g, '')
+      .replace(/^\s*\d+\.\s+/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    paragraphLines = [];
+
+    if (!stripped) {
+      return '';
+    }
+
+    return extractFirstSentenceFromText(stripped);
+  }
+
+  for (const originalLine of lines) {
+    const line = originalLine.trim();
+
+    if (!line) {
+      const sentence = processParagraph();
+      if (sentence) {
+        return sentence;
+      }
+      continue;
+    }
+
+    if (/^#{1,6}\s+/.test(line)) {
+      const sentence = processParagraph();
+      if (sentence) {
+        return sentence;
+      }
+      continue;
+    }
+
+    const cleanedLine = line
+      .replace(/^>+\s*/, '')
+      .replace(/^[-*+]\s+/, '')
+      .replace(/^\d+\.\s+/, '');
+
+    paragraphLines.push(cleanedLine);
+  }
+
+  return processParagraph();
+}

--- a/app/lib/writing.js
+++ b/app/lib/writing.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { getExternalWritingEntries } from './rss.js';
+import { extractFirstSentenceFromMarkdown } from './text.js';
 
 export const WRITING_CATEGORY_LABELS = {
   cryptocurrencies: 'Cryptocurrencies',
@@ -70,6 +71,8 @@ function readWritingMarkdown(category, slug) {
   const status = data?.status ? String(data.status).toLowerCase() : '';
   const description = data?.description ? String(data.description) : '';
 
+  const firstSentence = extractFirstSentenceFromMarkdown(content);
+
   return {
     category,
     slug,
@@ -79,6 +82,7 @@ function readWritingMarkdown(category, slug) {
     title,
     status,
     description,
+    firstSentence,
   };
 }
 
@@ -129,6 +133,7 @@ function normalizeLocalEntry(entry) {
     category: entry.category,
     publishedAtMs,
     source: 'local',
+    preview: entry.firstSentence,
   };
 }
 
@@ -171,10 +176,10 @@ export async function getLiveWritingByCategory() {
 
   for (const [category, label] of Object.entries(WRITING_CATEGORY_LABELS)) {
     const entries = sortEntries(combinedByCategory.get(category) ?? []).map(
-      ({ title, description, href }) => ({
+      ({ title, href, preview }) => ({
         title,
-        description,
         href,
+        preview,
       })
     );
 


### PR DESCRIPTION
## Summary
- reintroduce underlined writing links without emojis on the home page
- display first sentence previews parsed from local markdown and external feed summaries
- add shared utilities for extracting first sentences and wire them into writing data loaders

## Testing
- not run (requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_690118e2f4588329b53bf3075a28d006