### PR TITLE
Adjust donut chart summary font sizing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -405,7 +405,7 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 0.375rem;
+  font-size: 8px;
   color: var(--color-muted);
 }
 


### PR DESCRIPTION
## Summary
- update the donut chart summary items to use an 8px pixel-based font size
- align the top-language labels with the visual sizing of the bar chart day labels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69011a3b112483299277d4f937847206