### PR TITLE
Format writing previews and update link behavior

### DIFF
--- a/app/components/home/WritingSection.jsx
+++ b/app/components/home/WritingSection.jsx
@@ -14,20 +14,22 @@ export default function WritingSection({ sections }) {
           <div className={categoryClassName} key={label}>
             <p className="subsection-label">{label}</p>
             {hasEntries ? (
-              entries.map(({ title, href, preview }) => {
+              entries.map(({ title, href, preview, openInNewTab }) => {
                 const isExternal = /^https?:\/\//i.test(href);
                 const linkHref = isExternal ? href : `/${href}`;
+                const shouldOpenInNewTab = Boolean(openInNewTab) || isExternal;
+                const newTabAttributes = shouldOpenInNewTab
+                  ? {
+                      target: '_blank',
+                      rel: 'noopener noreferrer',
+                    }
+                  : {};
 
                 return (
                   <div className="home-writing-entry" key={href}>
                     <a
                       href={linkHref}
-                      {...(isExternal
-                        ? {
-                            target: '_blank',
-                            rel: 'noopener noreferrer',
-                          }
-                        : {})}
+                      {...newTabAttributes}
                     >
                       {title}
                     </a>

--- a/app/lib/rss.js
+++ b/app/lib/rss.js
@@ -1,4 +1,4 @@
-import { extractFirstSentenceFromText } from './text.js';
+import { decodeHtmlEntities, extractFirstSentenceFromText, formatPreviewText } from './text.js';
 
 const FEED_URLS = [
   'https://dev.to/feed/meeshbhoombah',
@@ -89,7 +89,8 @@ function decodeCdata(value) {
 function sanitizeHtmlToText(value) {
   if (!value) return '';
   const withoutCdata = decodeCdata(value);
-  return withoutCdata.replace(/<[^>]*>/g, '').trim();
+  const decoded = decodeHtmlEntities(withoutCdata);
+  return decoded.replace(/<[^>]*>/g, '').trim();
 }
 
 function createTagRegex(tagName) {
@@ -234,7 +235,9 @@ export async function getExternalWritingEntries() {
 
       const publishedAtMs = parseDateToMs(item.publishedAt);
 
-      const preview = extractFirstSentenceFromText(item.description);
+      const previewSource = extractFirstSentenceFromText(item.description);
+      const isDevToLink = /^https?:\/\/(?:www\.)?dev\.to\//i.test(item.link ?? '');
+      const preview = formatPreviewText(previewSource, { isDevToLink });
 
       return {
         title: item.title,

--- a/app/lib/text.js
+++ b/app/lib/text.js
@@ -6,7 +6,7 @@ const HTML_ENTITIES = {
   '&#39;': "'",
 };
 
-function decodeHtmlEntities(value) {
+export function decodeHtmlEntities(value) {
   if (!value) return '';
   return value.replace(/&(amp|lt|gt|quot|#39);/gi, (match) => {
     const decoded = HTML_ENTITIES[match.toLowerCase()];
@@ -105,4 +105,31 @@ export function extractFirstSentenceFromMarkdown(markdown) {
   }
 
   return processParagraph();
+}
+
+export function formatPreviewText(value, { isDevToLink = false } = {}) {
+  if (!value) {
+    return '';
+  }
+
+  let text = value.trim();
+
+  if (isDevToLink) {
+    text = text
+      .replace(/^(&lt;|<)p(&gt;|>)/i, '')
+      .replace(/(&lt;|<)\/p(&gt;|>)$/i, '')
+      .trim();
+  }
+
+  if (!text) {
+    return '';
+  }
+
+  const withoutOuterQuotes = text.replace(/^"+/, '').replace(/"+$/, '').trim();
+
+  if (!withoutOuterQuotes) {
+    return '';
+  }
+
+  return `"${withoutOuterQuotes}"`;
 }

--- a/app/lib/writing.js
+++ b/app/lib/writing.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { getExternalWritingEntries } from './rss.js';
-import { extractFirstSentenceFromMarkdown } from './text.js';
+import { extractFirstSentenceFromMarkdown, formatPreviewText } from './text.js';
 
 export const WRITING_CATEGORY_LABELS = {
   cryptocurrencies: 'Cryptocurrencies',
@@ -125,6 +125,8 @@ function parseDateToMs(value) {
 
 function normalizeLocalEntry(entry) {
   const publishedAtMs = parseDateToMs(entry?.data?.date);
+  const previewSource = entry.description || entry.firstSentence || '';
+  const preview = formatPreviewText(previewSource);
 
   return {
     title: entry.title,
@@ -133,7 +135,8 @@ function normalizeLocalEntry(entry) {
     category: entry.category,
     publishedAtMs,
     source: 'local',
-    preview: entry.firstSentence,
+    preview,
+    openInNewTab: true,
   };
 }
 
@@ -176,10 +179,11 @@ export async function getLiveWritingByCategory() {
 
   for (const [category, label] of Object.entries(WRITING_CATEGORY_LABELS)) {
     const entries = sortEntries(combinedByCategory.get(category) ?? []).map(
-      ({ title, href, preview }) => ({
+      ({ title, href, preview, openInNewTab }) => ({
         title,
         href,
         preview,
+        openInNewTab: Boolean(openInNewTab),
       })
     );
 


### PR DESCRIPTION
## Summary
- decode HTML entities when sanitizing RSS content and normalize dev.to previews
- wrap previews in quotes and use local descriptions for writing entry summaries
- open internal writing entries in a new tab while preserving external link handling

## Testing
- npm run lint *(fails: interactive Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_69011bdad09c832981d11913a598d27a