### PR TITLE
Prevent selecting donut chart

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -378,6 +378,9 @@ body {
   width: 160px;
   height: 160px;
   flex-shrink: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
 }
 
 .work-donut-chart__svg {
@@ -389,6 +392,9 @@ body {
 .work-donut-chart__segment {
   stroke-linecap: butt;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
 }
 
 .work-donut-chart__summary {


### PR DESCRIPTION
## Summary
- prevent selecting the donut chart by disabling text selection on the chart container and segments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690129fffca08329aea929282eee9ae5