### PR TITLE
Add GitHub contribution graph to digest section

### DIFF
--- a/app/components/home/DigestSection.jsx
+++ b/app/components/home/DigestSection.jsx
@@ -353,6 +353,24 @@ export default function DigestSection() {
           )}
         </div>
       </div>
+      <div className="github-contribution-graph work-chart-card">
+        <p className="subsection-label work-chart-title">GitHub Contributions</p>
+        <div className="github-contribution-graph__frame">
+          <a
+            href="https://github.com/Meeshbhoombah"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img
+              className="github-contribution-graph__image"
+              src="https://ghchart.rshah.org/Meeshbhoombah"
+              alt="A yearly GitHub contribution graph for Meeshbhoombah"
+              title="GitHub contributions for Meeshbhoombah"
+              loading="lazy"
+            />
+          </a>
+        </div>
+      </div>
     </section>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -256,6 +256,24 @@ body {
   background: color-mix(in srgb, var(--color-background) 92%, transparent);
 }
 
+.github-contribution-graph {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.github-contribution-graph__frame {
+  width: 100%;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.github-contribution-graph__image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
 .work-chart-title {
   font-size: 0.6rem;
   letter-spacing: 0.1em;


### PR DESCRIPTION
## Summary
- add a GitHub contribution graph card beneath the digest activity charts
- style the contribution graph container for responsive overflow handling and image sizing

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_690134c201c0832984d1e1938d3a4d9e