### PR TITLE
Hide digest charts on homepage

### DIFF
--- a/app/components/home/DigestSection.jsx
+++ b/app/components/home/DigestSection.jsx
@@ -34,6 +34,7 @@ const activityUrl =
   'https://wakatime.com/share/@Meeshbhoombah/6d82282c-df01-46bf-b408-7b359f933419.json';
 const languagesUrl =
   'https://wakatime.com/share/@Meeshbhoombah/8c7ee140-809e-4f98-bd17-3d553ec2bd75.json';
+const SHOW_DIGEST_CHARTS = false;
 
 function formatDuration(totalSeconds) {
   if (!totalSeconds) {
@@ -220,157 +221,161 @@ export default function DigestSection() {
           </div>
         ))}
       </div>
-      <div className="work-activity-charts">
-        <div className="work-chart-card">
-          <p className="subsection-label work-chart-title">Last 7 Days of Coding Activity</p>
-          {activityLoading ? (
-            <p className="work-chart-message">Loading activity…</p>
-          ) : activityError ? (
-            <p className="work-chart-message" role="alert">
-              Unable to load coding activity right now.
-            </p>
-          ) : activityData.length === 0 ? (
-            <p className="work-chart-message">No recent coding activity recorded.</p>
-          ) : (
-            <div
-              className="work-bar-chart"
-              role="list"
-              aria-label="Coding activity for the last seven days"
-            >
-              {activityData.map(({ label, totalSeconds, displayValue }) => {
-                const height = maxActivitySeconds
-                  ? Math.max((totalSeconds / maxActivitySeconds) * 100, 4)
-                  : 4;
-                return (
-                  <div className="work-bar-chart__item" key={label} role="listitem">
-                    <div className="work-bar-chart__column">
-                      <span
-                        className="work-bar-chart__bar"
-                        style={{ height: `${height}%` }}
-                        aria-label={`${label}: ${displayValue}`}
-                        tabIndex={0}
-                      />
-                      <span className="work-bar-chart__label">{label}</span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-        <div className="work-chart-card">
-          <p className="subsection-label work-chart-title work-chart-title--right">
-            Languages Used (Last 30 Days)
-          </p>
-          {languagesLoading ? (
-            <p className="work-chart-message">Loading languages…</p>
-          ) : languagesError ? (
-            <p className="work-chart-message" role="alert">
-              Unable to load languages right now.
-            </p>
-          ) : languagesData.length === 0 ? (
-            <p className="work-chart-message">No language data available.</p>
-          ) : (
-            <div className="work-donut-chart">
-              <div className="work-donut-chart__visual">
-                <svg
-                  className="work-donut-chart__svg"
-                  viewBox="0 0 120 120"
-                  role="img"
-                  aria-label="Language usage for the past thirty days"
+      {SHOW_DIGEST_CHARTS && (
+        <>
+          <div className="work-activity-charts">
+            <div className="work-chart-card">
+              <p className="subsection-label work-chart-title">Last 7 Days of Coding Activity</p>
+              {activityLoading ? (
+                <p className="work-chart-message">Loading activity…</p>
+              ) : activityError ? (
+                <p className="work-chart-message" role="alert">
+                  Unable to load coding activity right now.
+                </p>
+              ) : activityData.length === 0 ? (
+                <p className="work-chart-message">No recent coding activity recorded.</p>
+              ) : (
+                <div
+                  className="work-bar-chart"
+                  role="list"
+                  aria-label="Coding activity for the last seven days"
                 >
-                  <title>Language usage for the past thirty days</title>
-                  {(() => {
-                    const radius = 50;
-                    const circumference = 2 * Math.PI * radius;
-                    let cumulativePercent = 0;
-
-                    return languagesData.map((language, index) => {
-                      const { name, percent, color } = language;
-                      const startPercent = cumulativePercent;
-                      cumulativePercent += percent;
-                      const dash = Math.max((percent / 100) * circumference, 0);
-                      const gap = Math.max(circumference - dash, 0);
-
-                      return (
-                        <circle
-                          key={`${name}-${index}`}
-                          className="work-donut-chart__segment"
-                          cx="60"
-                          cy="60"
-                          r={radius}
-                          fill="transparent"
-                          stroke={color}
-                          strokeWidth="20"
-                          strokeDasharray={`${dash} ${gap}`}
-                          strokeDashoffset={circumference * (1 - startPercent / 100)}
-                          transform="rotate(-90 60 60)"
-                          tabIndex={0}
-                          aria-label={`${name}: ${percent.toFixed(1)} percent`}
-                          onMouseEnter={() => setHoveredLanguage(language)}
-                          onMouseLeave={() => setHoveredLanguage(null)}
-                          onFocus={() => setHoveredLanguage(language)}
-                          onBlur={() => setHoveredLanguage(null)}
-                        />
-                      );
-                    });
-                  })()}
-                </svg>
-                <div className="work-donut-chart__center" aria-live="polite">
-                  {activeLanguage && (
-                    <>
-                      <span className="work-donut-chart__center-name">
-                        {activeLanguage.name}
-                      </span>
-                      <span className="work-donut-chart__center-value">
-                        {activeLanguage.percent.toFixed(1)}%
-                      </span>
-                    </>
-                  )}
+                  {activityData.map(({ label, totalSeconds, displayValue }) => {
+                    const height = maxActivitySeconds
+                      ? Math.max((totalSeconds / maxActivitySeconds) * 100, 4)
+                      : 4;
+                    return (
+                      <div className="work-bar-chart__item" key={label} role="listitem">
+                        <div className="work-bar-chart__column">
+                          <span
+                            className="work-bar-chart__bar"
+                            style={{ height: `${height}%` }}
+                            aria-label={`${label}: ${displayValue}`}
+                            tabIndex={0}
+                          />
+                          <span className="work-bar-chart__label">{label}</span>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
-              </div>
-              {topLanguages.length > 0 && (
-                <ul className="work-donut-chart__summary" aria-label="Top three languages">
-                  {topLanguages.map(({ name, percent, color }) => (
-                    <li
-                      className="work-donut-chart__summary-item"
-                      key={`${name}-${percent.toFixed(1)}`}
-                    >
-                      <span
-                        className="work-donut-chart__summary-color"
-                        style={{ backgroundColor: color }}
-                        aria-hidden="true"
-                      />
-                      <span className="work-donut-chart__summary-name">{name}</span>
-                      <span className="work-donut-chart__summary-value">
-                        {percent.toFixed(1)}%
-                      </span>
-                    </li>
-                  ))}
-                </ul>
               )}
             </div>
-          )}
-        </div>
-      </div>
-      <div className="github-contribution-graph work-chart-card">
-        <p className="subsection-label work-chart-title">GitHub Contributions</p>
-        <div className="github-contribution-graph__frame">
-          <a
-            href="https://github.com/Meeshbhoombah"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img
-              className="github-contribution-graph__image"
-              src="https://ghchart.rshah.org/Meeshbhoombah"
-              alt="A yearly GitHub contribution graph for Meeshbhoombah"
-              title="GitHub contributions for Meeshbhoombah"
-              loading="lazy"
-            />
-          </a>
-        </div>
-      </div>
+            <div className="work-chart-card">
+              <p className="subsection-label work-chart-title work-chart-title--right">
+                Languages Used (Last 30 Days)
+              </p>
+              {languagesLoading ? (
+                <p className="work-chart-message">Loading languages…</p>
+              ) : languagesError ? (
+                <p className="work-chart-message" role="alert">
+                  Unable to load languages right now.
+                </p>
+              ) : languagesData.length === 0 ? (
+                <p className="work-chart-message">No language data available.</p>
+              ) : (
+                <div className="work-donut-chart">
+                  <div className="work-donut-chart__visual">
+                    <svg
+                      className="work-donut-chart__svg"
+                      viewBox="0 0 120 120"
+                      role="img"
+                      aria-label="Language usage for the past thirty days"
+                    >
+                      <title>Language usage for the past thirty days</title>
+                      {(() => {
+                        const radius = 50;
+                        const circumference = 2 * Math.PI * radius;
+                        let cumulativePercent = 0;
+
+                        return languagesData.map((language, index) => {
+                          const { name, percent, color } = language;
+                          const startPercent = cumulativePercent;
+                          cumulativePercent += percent;
+                          const dash = Math.max((percent / 100) * circumference, 0);
+                          const gap = Math.max(circumference - dash, 0);
+
+                          return (
+                            <circle
+                              key={`${name}-${index}`}
+                              className="work-donut-chart__segment"
+                              cx="60"
+                              cy="60"
+                              r={radius}
+                              fill="transparent"
+                              stroke={color}
+                              strokeWidth="20"
+                              strokeDasharray={`${dash} ${gap}`}
+                              strokeDashoffset={circumference * (1 - startPercent / 100)}
+                              transform="rotate(-90 60 60)"
+                              tabIndex={0}
+                              aria-label={`${name}: ${percent.toFixed(1)} percent`}
+                              onMouseEnter={() => setHoveredLanguage(language)}
+                              onMouseLeave={() => setHoveredLanguage(null)}
+                              onFocus={() => setHoveredLanguage(language)}
+                              onBlur={() => setHoveredLanguage(null)}
+                            />
+                          );
+                        });
+                      })()}
+                    </svg>
+                    <div className="work-donut-chart__center" aria-live="polite">
+                      {activeLanguage && (
+                        <>
+                          <span className="work-donut-chart__center-name">
+                            {activeLanguage.name}
+                          </span>
+                          <span className="work-donut-chart__center-value">
+                            {activeLanguage.percent.toFixed(1)}%
+                          </span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  {topLanguages.length > 0 && (
+                    <ul className="work-donut-chart__summary" aria-label="Top three languages">
+                      {topLanguages.map(({ name, percent, color }) => (
+                        <li
+                          className="work-donut-chart__summary-item"
+                          key={`${name}-${percent.toFixed(1)}`}
+                        >
+                          <span
+                            className="work-donut-chart__summary-color"
+                            style={{ backgroundColor: color }}
+                            aria-hidden="true"
+                          />
+                          <span className="work-donut-chart__summary-name">{name}</span>
+                          <span className="work-donut-chart__summary-value">
+                            {percent.toFixed(1)}%
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="github-contribution-graph work-chart-card">
+            <p className="subsection-label work-chart-title">GitHub Contributions</p>
+            <div className="github-contribution-graph__frame">
+              <a
+                href="https://github.com/Meeshbhoombah"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <img
+                  className="github-contribution-graph__image"
+                  src="https://ghchart.rshah.org/Meeshbhoombah"
+                  alt="A yearly GitHub contribution graph for Meeshbhoombah"
+                  title="GitHub contributions for Meeshbhoombah"
+                  loading="lazy"
+                />
+              </a>
+            </div>
+          </div>
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add a flag to temporarily hide the digest charts on the homepage while retaining the components for later use

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_69030bc278588329a63e2be0da3fbedc