### PR TITLE
Update tech events stat in digest

### DIFF
--- a/app/components/home/DigestSection.jsx
+++ b/app/components/home/DigestSection.jsx
@@ -27,7 +27,7 @@ const stats = [
     value: '>3,098',
     description: 'Hours dedicated to diversifying tech through education',
   },
-  { value: '~100', description: 'Projects Built' },
+  { value: '~132', description: 'Tech Events Organized' },
 ];
 
 const activityUrl =


### PR DESCRIPTION
## Summary
- update the digest statistics card to show that approximately 132 tech events have been organized instead of 100 projects built

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691642f898c08329be7e11bbbb3cd3c5)