### PR TITLE
Remove column divider border

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -593,7 +593,6 @@ body {
 .writing-article-body blockquote {
   margin: 16px 0;
   padding-left: 1rem;
-  border-left: 3px solid var(--color-muted);
 }
 
 .writing-article-body code {


### PR DESCRIPTION
## Summary
- remove the blockquote border in the writing article layout so the left and right columns are no longer visually divided

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691664ce220c8329a03a7209cfd6e967)